### PR TITLE
feat(structure): add homepage with login and signup navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ app.get('/', (req, res) => {
   if (req.session && req.session.userId) {
     return res.redirect('/lecturer/dashboard');
   }
-  return res.redirect('/login');
+  return res.render('homepage');
 })
 
 if (require.main === module) {

--- a/src/views/homepage.html
+++ b/src/views/homepage.html
@@ -6,30 +6,22 @@
   <title>KnockKnock.prof</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body>
+<body class="bg-light">
   <nav class="navbar navbar-dark bg-dark px-4">
-    <span class="navbar-brand">KnockKnock.prof</span>
+    <span class="navbar-brand fw-bold">KnockKnock.prof</span>
   </nav>
 
   <main class="container mt-5">
     <div class="row justify-content-center">
       <div class="col-md-6 text-center">
-        <p class="text-muted mb-4">Knock Knock, who's there? </p>
-        <a href="/lecturer/dashboard" class="btn btn-primary btn-lg">Lecturer Dashboard</a>
-        <a href="/student/dashboard"  class="btn btn-outline-primary btn-lg ms-2">Student Dashboard</a>
+        <h1 class="mb-2">Knock Knock, Prof</h1>
+        <p class="text-muted mb-4">Schedule consultations with your lecturers.</p>
+        <a href="/login"   class="btn btn-primary btn-lg me-2">Log In</a>
+        <a href="/sign/up" class="btn btn-outline-primary btn-lg">Sign Up</a>
       </div>
     </div>
   </main>
-</body>
-</html>
 
-  <main class="container mt-5">
-    <div class="row justify-content-center">
-      <div class="col-md-6 text-center">
-        <p class="text-muted mb-4">Knock Knock, who's there? </p>
-        <a href="/sig/up" class="btn btn-primary btn-lg">signup</a>
-      </div>
-    </div>
-  </main>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
**What was changed**
- Added homepage as the app entry point with Log In and Sign Up navigation buttons
- Root route (/) now renders the homepage for unauthenticated users
- Logged-in users visiting (/) are redirected to their dashboard
- Fixed broken homepage HTML (duplicate body/html tags and wrong signup link)

**Why it was changed**
Provides a proper entry point for the application so unauthenticated users are greeted with a homepage rather than being sent directly to the login page.

**What to review**
- Root route logic and redirect behaviour for authenticated users
- Homepage HTML structure and navigation links
- Fix for duplicate body/html tags