### PR TITLE
feat(signup): add Wits email domain validation for student and lecturer

### DIFF
--- a/src/controllers/signup-controller.js
+++ b/src/controllers/signup-controller.js
@@ -19,12 +19,15 @@ const registerUser = (req, res) => {
       return res.status(400).send('Passwords do not match')
     }
 
-    let role = ''
-    // Determine role based on number
-    if (number && number.toUpperCase().startsWith('A')) {
-      role = 'lecturer'
-    } else {
-      role = 'student'
+    const role = (number && number.toUpperCase().startsWith('A')) ? 'lecturer' : 'student'
+
+    const emailLower = (email || '').toLowerCase()
+    const validEmail = role === 'lecturer'
+      ? /^[^@]+@wits\.ac\.za$/.test(emailLower)
+      : /^[^@]+@students\.wits\.ac\.za$/.test(emailLower)
+
+    if (!validEmail) {
+      return res.render('sign-up', { message: null, error: 'Please use your Wits email address.' })
     }
 
     // Database Insertion

--- a/src/views/sign-up.html
+++ b/src/views/sign-up.html
@@ -50,6 +50,7 @@
         <div class="mb-3">
             <label for="email" class="form-label fw-semibold">University Email</label>
             <input type="email" class="form-control" id="email" name="email" required>
+            <div class="form-text" id="emailHint">Enter your Wits email address.</div>
         </div>
 
         <div class="mb-3">
@@ -92,6 +93,21 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   
   <script>
+    const numberInput = document.getElementById('number');
+    const emailInput  = document.getElementById('email');
+    const emailHint   = document.getElementById('emailHint');
+
+    numberInput.addEventListener('input', () => {
+      const isLecturer = numberInput.value.trim().toUpperCase().startsWith('A');
+      if (isLecturer) {
+        emailInput.pattern = '^[^@]+@wits\\.ac\\.za$';
+        emailHint.textContent = 'Lecturers: use your @wits.ac.za email';
+      } else {
+        emailInput.pattern = '^[^@]+@students\\.wits\\.ac\\.za$';
+        emailHint.textContent = 'Students: use your @students.wits.ac.za email';
+      }
+    });
+
     const courseInput = document.getElementById("coursesInput");
     const addCourseBtn = document.getElementById("addBtn");
     const courseList = document.getElementById("list");

--- a/tests/unit/signup-controller.test.js
+++ b/tests/unit/signup-controller.test.js
@@ -1,0 +1,77 @@
+/* eslint-env jest */
+const { registerUser } = require('../../src/controllers/signup-controller');
+
+jest.mock('../../database/db', () => ({ prepare: jest.fn() }));
+
+const db = require('../../database/db');
+
+const mockReq = (body = {}) => ({ body });
+
+const mockRes = () => {
+  const res = {};
+  res.render    = jest.fn();
+  res.redirect  = jest.fn();
+  res.status    = jest.fn().mockReturnValue({ send: jest.fn() });
+  return res;
+};
+
+beforeEach(() => {
+  db.prepare.mockReset();
+});
+
+describe('email domain validation', () => {
+  test('accepts student email ending in @students.wits.ac.za', () => {
+    db.prepare.mockReturnValue({ run: jest.fn() });
+
+    const req = mockReq({ fullName: 'Test Student', number: '1234567', email: 'student@students.wits.ac.za', password: 'pass', confirmPassword: 'pass', specificDetail: 'BSCENGINFO' });
+    const res = mockRes();
+    registerUser(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith('/login?success=Account+created!+Please+log+in.');
+  });
+
+  test('accepts lecturer email ending in @wits.ac.za', () => {
+    db.prepare.mockReturnValue({ run: jest.fn() });
+
+    const req = mockReq({ fullName: 'Test Lecturer', number: 'A000999', email: 'lecturer@wits.ac.za', password: 'pass', confirmPassword: 'pass', specificDetail: 'EIE' });
+    const res = mockRes();
+    registerUser(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith('/login?success=Account+created!+Please+log+in.');
+  });
+
+  test('rejects student email not ending in @students.wits.ac.za', () => {
+    const req = mockReq({ fullName: 'Test Student', number: '1234567', email: 'student@gmail.com', password: 'pass', confirmPassword: 'pass', specificDetail: 'BSCENGINFO' });
+    const res = mockRes();
+    registerUser(req, res);
+
+    expect(res.render).toHaveBeenCalledWith('sign-up', {
+      message: null,
+      error: 'Please use your Wits email address.',
+    });
+    expect(db.prepare).not.toHaveBeenCalled();
+  });
+
+  test('rejects lecturer email not ending in @wits.ac.za', () => {
+    const req = mockReq({ fullName: 'Test Lecturer', number: 'A000999', email: 'lecturer@gmail.com', password: 'pass', confirmPassword: 'pass', specificDetail: 'EIE' });
+    const res = mockRes();
+    registerUser(req, res);
+
+    expect(res.render).toHaveBeenCalledWith('sign-up', {
+      message: null,
+      error: 'Please use your Wits email address.',
+    });
+    expect(db.prepare).not.toHaveBeenCalled();
+  });
+
+  test('rejects student email using @wits.ac.za instead of @students.wits.ac.za', () => {
+    const req = mockReq({ fullName: 'Test Student', number: '1234567', email: 'student@wits.ac.za', password: 'pass', confirmPassword: 'pass', specificDetail: 'BSCENGINFO' });
+    const res = mockRes();
+    registerUser(req, res);
+
+    expect(res.render).toHaveBeenCalledWith('sign-up', {
+      message: null,
+      error: 'Please use your Wits email address.',
+    });
+  });
+});


### PR DESCRIPTION
Closes #50  

## What was changed

- Added server-side validation in the signup controller.
- Students must register using an `@students.wits.ac.za` email address.
- Lecturers must register using an `@wits.ac.za` email address.
- Signups with non-Wits email domains are rejected with the message:

  > Please use your Wits email address.

- Added client-side hint text that updates dynamically as the user types their student or staff number.

## Why it was changed

This addresses issue #50 by preventing users from registering with personal email addresses.

The change ensures that only valid Wits students and staff can create accounts. Since the validation is done server-side, users cannot bypass it using browser developer tools.

## Testing

Added `tests/unit/signup-controller.test.js` with 5 unit tests covering:

- Student signup with `@students.wits.ac.za` is accepted.
- Lecturer signup with `@wits.ac.za` is accepted.
- Signup with `@gmail.com` is rejected with the correct error message.
- Lecturer email domain is rejected for student signup.
- Student using lecturer domain `@wits.ac.za` is rejected.