### PR TITLE
feat(availability): implement save and delete for lecturer availabili…

### DIFF
--- a/src/controllers/availability-controller.js
+++ b/src/controllers/availability-controller.js
@@ -1,7 +1,14 @@
 const db = require('../../database/db');
+const { validateSlotFields, isBusinessHours, isOverlapping } = require('../services/availability-helpers');
 
-const getAvailability = (lecturerId) =>
-  db.prepare('SELECT * FROM consultations WHERE lecturer_id = ? ORDER BY consultation_date ASC, consultation_time ASC').all(lecturerId);
+const getAvailability = (staffNumber) =>
+  db.prepare(`
+    SELECT * FROM lecturer_availability
+    WHERE staff_number = ?
+    ORDER BY
+      CASE day_of_week WHEN 'Mon' THEN 1 WHEN 'Tue' THEN 2 WHEN 'Wed' THEN 3 WHEN 'Thu' THEN 4 WHEN 'Fri' THEN 5 END,
+      start_time
+  `).all(staffNumber);
 
 const showAvailability = (req, res) => {
   const user = { id: req.session.userId, name: req.session.userName, role: req.session.userRole };
@@ -10,21 +17,54 @@ const showAvailability = (req, res) => {
 
 const saveAvailability = (req, res) => {
   const user = { id: req.session.userId, name: req.session.userName, role: req.session.userRole };
+  const { day_of_week, start_time, end_time, venue, max_number_of_students } = req.body;
+
+  if (!validateSlotFields({ day_of_week, start_time, end_time, venue, max_number_of_students })) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: 'All fields are required.', success: null
+    });
+  }
+
+  if (!isBusinessHours(start_time, end_time)) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: 'Slots must be between 08:00 and 18:00, with end time after start time.',
+      success: null
+    });
+  }
+
+  const existing = db.prepare(
+    'SELECT * FROM lecturer_availability WHERE staff_number = ? AND day_of_week = ?'
+  ).all(user.id, day_of_week);
+
+  if (isOverlapping(existing, start_time, end_time)) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: 'This slot overlaps with an existing availability slot.',
+      success: null
+    });
+  }
+
+  db.prepare(
+    'INSERT INTO lecturer_availability (staff_number, day_of_week, start_time, end_time, venue, max_number_of_students) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run(user.id, day_of_week, start_time, end_time, venue, Number(max_number_of_students));
+
   return res.render('availability', {
-    user,
-    availability: getAvailability(user.id),
-    error: null,
-    success: 'Availability saving is coming soon. This feature requires the lecturer_availability table.'
+    user, availability: getAvailability(user.id),
+    error: null, success: 'Availability slot saved.'
   });
 };
 
 const deleteAvailability = (req, res) => {
   const user = { id: req.session.userId, name: req.session.userName, role: req.session.userRole };
+  db.prepare(
+    'DELETE FROM lecturer_availability WHERE availability_id = ? AND staff_number = ?'
+  ).run(req.params.id, user.id);
+
   return res.render('availability', {
-    user,
-    availability: getAvailability(user.id),
-    error: null,
-    success: 'Slot deletion is coming soon. This feature requires the lecturer_availability table.'
+    user, availability: getAvailability(user.id),
+    error: null, success: 'Slot deleted.'
   });
 };
 

--- a/src/services/availability-helpers.js
+++ b/src/services/availability-helpers.js
@@ -3,8 +3,8 @@ const generateConstId = (date, count) => {
   return `${date}-${sequence}`;
 };
 
-const validateSlotFields = ({ consultation_date, consultation_time, consultation_end_time, venue, max_number_of_students }) => {
-  return !!(consultation_date && consultation_time && consultation_end_time && venue && max_number_of_students);
+const validateSlotFields = ({ day_of_week, start_time, end_time, venue, max_number_of_students }) => {
+  return !!(day_of_week && start_time && end_time && venue && max_number_of_students);
 };
 
 const toMinutes = (timeStr) => {
@@ -26,8 +26,8 @@ const isOverlapping = (existingSlots, startTime, endTime) => {
   const newStart = toMinutes(startTime);
   const newEnd = toMinutes(endTime);
   return existingSlots.some(slot => {
-    const existStart = toMinutes(slot.consultation_time);
-    const existEnd = existStart + (slot.duration_min || 0);
+    const existStart = toMinutes(slot.start_time);
+    const existEnd = toMinutes(slot.end_time);
     return newStart < existEnd && newEnd > existStart;
   });
 };

--- a/src/views/availability.html
+++ b/src/views/availability.html
@@ -45,19 +45,26 @@
           <form action="/lecturer/availability" method="POST">
 
             <div class="mb-3">
-              <label for="consultation_date" class="form-label fw-semibold">Date</label>
-              <input type="date" class="form-control" id="consultation_date" name="consultation_date" required>
+              <label for="day_of_week" class="form-label fw-semibold">Day</label>
+              <select class="form-select" id="day_of_week" name="day_of_week" required>
+                <option value="" disabled selected>Select a day</option>
+                <option value="Mon">Monday</option>
+                <option value="Tue">Tuesday</option>
+                <option value="Wed">Wednesday</option>
+                <option value="Thu">Thursday</option>
+                <option value="Fri">Friday</option>
+              </select>
             </div>
 
             <div class="row g-3 mb-3">
               <div class="col-6">
-                <label for="consultation_time" class="form-label fw-semibold">Start Time</label>
-                <input type="time" class="form-control" id="consultation_time" name="consultation_time"
+                <label for="start_time" class="form-label fw-semibold">Start Time</label>
+                <input type="time" class="form-control" id="start_time" name="start_time"
                   min="08:00" max="18:00" required>
               </div>
               <div class="col-6">
-                <label for="consultation_end_time" class="form-label fw-semibold">End Time</label>
-                <input type="time" class="form-control" id="consultation_end_time" name="consultation_end_time"
+                <label for="end_time" class="form-label fw-semibold">End Time</label>
+                <input type="time" class="form-control" id="end_time" name="end_time"
                   min="08:00" max="18:00" required>
               </div>
             </div>
@@ -74,7 +81,7 @@
                 name="max_number_of_students" min="1" max="10" value="1" required>
             </div>
 
-            <button type="button" class="btn btn-primary w-100" onclick="showComingSoon()">Save Slot</button>
+            <button type="submit" class="btn btn-primary w-100">Save Slot</button>
           </form>
         </div>
       </div>
@@ -90,36 +97,26 @@
                 <caption class="visually-hidden">Your current availability slots</caption>
                 <thead>
                   <tr>
-                    <th scope="col">Date</th>
+                    <th scope="col">Day</th>
                     <th scope="col">Start</th>
                     <th scope="col">End</th>
                     <th scope="col">Venue</th>
                     <th scope="col">Max</th>
-                    <th scope="col">Status</th>
                     <th scope="col"></th>
                   </tr>
                 </thead>
                 <tbody>
-                  <% availability.forEach(slot => {
-                    const [h, m] = slot.consultation_time.split(':').map(Number);
-                    const endMin = h * 60 + m + slot.duration_min;
-                    const endTime = String(Math.floor(endMin / 60)).padStart(2,'0') + ':' + String(endMin % 60).padStart(2,'0');
-                  %>
+                  <% availability.forEach(slot => { %>
                     <tr>
-                      <td class="text-nowrap"><%= slot.consultation_date %></td>
-                      <td class="text-nowrap"><%= slot.consultation_time %></td>
-                      <td class="text-nowrap"><%= endTime %></td>
+                      <td class="text-nowrap"><%= slot.day_of_week %></td>
+                      <td class="text-nowrap"><%= slot.start_time %></td>
+                      <td class="text-nowrap"><%= slot.end_time %></td>
                       <td><%= slot.venue %></td>
                       <td><%= slot.max_number_of_students %></td>
                       <td>
-                        <span class="badge <%= slot.status === 'Available' ? 'bg-success' : 'bg-primary' %>">
-                          <%= slot.status %>
-                        </span>
-                      </td>
-                      <td>
-                        <% if (slot.status === 'Available') { %>
-                          <button type="button" class="btn btn-outline-danger btn-sm" onclick="showComingSoon()">Delete</button>
-                        <% } %>
+                        <form action="/lecturer/availability/<%= slot.availability_id %>/delete" method="POST" class="d-inline">
+                          <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>
+                        </form>
                       </td>
                     </tr>
                   <% }); %>
@@ -134,28 +131,5 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-
-  <div class="modal fade" id="comingSoonModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">Coming Soon</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          This feature is not yet available. It will be enabled once the availability table has been set up by the team.
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">OK</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <script>
-    function showComingSoon() {
-      new bootstrap.Modal(document.getElementById('comingSoonModal')).show();
-    }
-  </script>
 </body>
 </html>

--- a/tests/unit/availability-controller.test.js
+++ b/tests/unit/availability-controller.test.js
@@ -1,9 +1,7 @@
 /* eslint-env jest */
 const { showAvailability, saveAvailability, deleteAvailability } = require('../../src/controllers/availability-controller');
 
-jest.mock('../../database/db', () => ({
-  prepare: jest.fn()
-}));
+jest.mock('../../database/db', () => ({ prepare: jest.fn() }));
 
 const db = require('../../database/db');
 
@@ -16,18 +14,19 @@ const mockReq = (overrides = {}) => ({
 
 const mockRes = () => {
   const res = {};
-  res.render = jest.fn();
+  res.render   = jest.fn();
   res.redirect = jest.fn();
   return res;
 };
 
-describe('showAvailability', () => {
-  beforeEach(() => db.prepare.mockReset());
+const fakeSlots = [
+  { availability_id: 1, staff_number: 'A000356', day_of_week: 'Mon', start_time: '09:00', end_time: '10:00', venue: 'Room 1', max_number_of_students: 1 }
+];
 
+beforeEach(() => db.prepare.mockReset());
+
+describe('showAvailability', () => {
   test('renders availability page with existing slots for the lecturer', () => {
-    const fakeSlots = [
-      { const_id: '2026-05-01-00001', consultation_date: '2026-05-01', consultation_time: '09:00', venue: 'Room 1' }
-    ];
     db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue(fakeSlots) });
 
     const res = mockRes();
@@ -54,35 +53,97 @@ describe('showAvailability', () => {
 });
 
 describe('saveAvailability', () => {
-  beforeEach(() => db.prepare.mockReset());
+  const validBody = {
+    day_of_week: 'Mon', start_time: '09:00', end_time: '10:00',
+    venue: 'Room 1', max_number_of_students: '1'
+  };
 
-  test('renders coming soon message without saving to the database', () => {
-    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) });
+  test('saves slot and renders success when all fields are valid and no overlap', () => {
+    db.prepare
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })  // overlap check
+      .mockReturnValueOnce({ run: jest.fn() })                       // INSERT
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(fakeSlots) }); // getAvailability after save
+
+    const req = mockReq({ body: validBody });
     const res = mockRes();
-
-    saveAvailability(mockReq(), res);
+    saveAvailability(req, res);
 
     expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
-      success: expect.stringContaining('coming soon'),
+      success: 'Availability slot saved.',
       error: null
     }));
-    expect(res.redirect).not.toHaveBeenCalled();
+  });
+
+  test('saves slot with correct staff_number from session', () => {
+    const runFn = jest.fn();
+    db.prepare
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+      .mockReturnValueOnce({ run: runFn })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) });
+
+    saveAvailability(mockReq({ body: validBody }), mockRes());
+
+    expect(runFn).toHaveBeenCalledWith('A000356', 'Mon', '09:00', '10:00', 'Room 1', 1);
+  });
+
+  test('renders error when required fields are missing', () => {
+    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) });
+
+    const req = mockReq({ body: { day_of_week: '', start_time: '', end_time: '', venue: '', max_number_of_students: '' } });
+    const res = mockRes();
+    saveAvailability(req, res);
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: 'All fields are required.',
+      success: null
+    }));
+  });
+
+  test('renders error when slot is outside business hours', () => {
+    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) });
+
+    const req = mockReq({ body: { ...validBody, start_time: '07:00', end_time: '08:00' } });
+    const res = mockRes();
+    saveAvailability(req, res);
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: expect.stringContaining('08:00 and 18:00'),
+      success: null
+    }));
+  });
+
+  test('renders error when new slot overlaps an existing slot', () => {
+    const existingSlot = { start_time: '09:00', end_time: '10:00' };
+    db.prepare
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([existingSlot]) })  // overlap check finds conflict
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([existingSlot]) }); // getAvailability for render
+
+    const req = mockReq({ body: { ...validBody, start_time: '09:30', end_time: '10:30' } });
+    const res = mockRes();
+    saveAvailability(req, res);
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: expect.stringContaining('overlaps'),
+      success: null
+    }));
   });
 });
 
 describe('deleteAvailability', () => {
-  beforeEach(() => db.prepare.mockReset());
+  test('deletes slot by id and staff_number then renders success', () => {
+    const runFn = jest.fn();
+    db.prepare
+      .mockReturnValueOnce({ run: runFn })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) });
 
-  test('renders coming soon message without deleting from the database', () => {
-    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) });
+    const req = mockReq({ params: { id: '1' } });
     const res = mockRes();
+    deleteAvailability(req, res);
 
-    deleteAvailability(mockReq({ params: { id: '2026-05-01-00001' } }), res);
-
+    expect(runFn).toHaveBeenCalledWith('1', 'A000356');
     expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
-      success: expect.stringContaining('coming soon'),
+      success: 'Slot deleted.',
       error: null
     }));
-    expect(res.redirect).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/availability-helpers.test.js
+++ b/tests/unit/availability-helpers.test.js
@@ -17,19 +17,19 @@ describe('generateConstId()', () => {
 describe('validateSlotFields()', () => {
   test('returns true when all fields are present', () => {
     expect(validateSlotFields({
-      consultation_date: '2026-05-01',
-      consultation_time: '09:00',
-      consultation_end_time: '10:00',
+      day_of_week: 'Mon',
+      start_time: '09:00',
+      end_time: '10:00',
       venue: 'Room 1',
       max_number_of_students: '5'
     })).toBe(true);
   });
 
-  test('returns false when consultation_date is missing', () => {
+  test('returns false when day_of_week is missing', () => {
     expect(validateSlotFields({
-      consultation_date: '',
-      consultation_time: '09:00',
-      consultation_end_time: '10:00',
+      day_of_week: '',
+      start_time: '09:00',
+      end_time: '10:00',
       venue: 'Room 1',
       max_number_of_students: '5'
     })).toBe(false);
@@ -37,10 +37,20 @@ describe('validateSlotFields()', () => {
 
   test('returns false when venue is missing', () => {
     expect(validateSlotFields({
-      consultation_date: '2026-05-01',
-      consultation_time: '09:00',
-      consultation_end_time: '10:00',
+      day_of_week: 'Mon',
+      start_time: '09:00',
+      end_time: '10:00',
       venue: '',
+      max_number_of_students: '5'
+    })).toBe(false);
+  });
+
+  test('returns false when start_time is missing', () => {
+    expect(validateSlotFields({
+      day_of_week: 'Mon',
+      start_time: '',
+      end_time: '10:00',
+      venue: 'Room 1',
       max_number_of_students: '5'
     })).toBe(false);
   });
@@ -80,7 +90,7 @@ describe('computeDuration()', () => {
 
 describe('isOverlapping()', () => {
   const existingSlots = [
-    { consultation_time: '09:00', duration_min: 60 },
+    { start_time: '09:00', end_time: '10:00' },
   ];
 
   test('returns false when new slot does not overlap', () => {


### PR DESCRIPTION
Closes #46  
Related: #7

## What was changed

### Lecturer Availability Management

- Replaced the stubbed “coming soon” controller with a fully working implementation.
- Lecturers can add recurring weekly availability slots with:
  - Day of week
  - Start time
  - End time
  - Venue
  - Maximum number of students
- Availability slots are saved to the `lecturer_availability` table using the lecturer’s `staff_number` from the session.
- Lecturers can delete an existing availability slot directly from the availability page.
- Availability slots are displayed in day and time order from Monday to Friday.

### Validation

- All fields are required.
- Missing fields return a clear error message.
- Availability slots must fall within `08:00–18:00`.
- Slots outside this range are rejected.
- Overlapping slots for the same lecturer on the same day are rejected.

### View

- Replaced the date picker with a day-of-week dropdown from Monday to Friday to reflect recurring weekly availability.
- Save and Delete buttons now submit real forms instead of showing a “coming soon” modal.
- Updated the table to display:
  - `day_of_week`
  - `start_time`
  - `end_time`

## Why it was changed

This addresses issue #46.

This change completes the implementation so lecturers can declare their weekly availability, which is required before students can book consultations within valid time windows.

## Testing
The tests cover:

- Saving slots with the correct `staff_number` from the session.
- Rejecting missing fields with an error.
- Rejecting slots outside `08:00–18:00`.
- Rejecting overlapping slots.
- Deleting slots by `availability_id` and `staff_number`.
- Updating `validateSlotFields` and `isOverlapping` for the `lecturer_availability` schema.