### PR TITLE
Signup middleware

### DIFF
--- a/src/controllers/signup-controller.js
+++ b/src/controllers/signup-controller.js
@@ -29,18 +29,23 @@ const registerUser = (req, res) => {
       return res.render('sign-up', { message: null, error: 'Please use your Wits email address.' })
     }
 
-    const user = req.session && req.session.userId
-      ? {
-          id: req.session.userId,
-          name: req.session.userName,
-          role: req.session.userRole
-        }
-      : {
-          id: number,
-          name: fullName,
-          role: (number && number.toUpperCase().startsWith('A')) ? 'lecturer' : 'student'
-        }
+    // const user = req.session && req.session.userId
+    //   ? {
+    //       id: req.session.userId,
+    //       name: req.session.userName,
+    //       role: req.session.userRole
+    //     }
+    //   : {
+    //       id: number,
+    //       name: fullName,
+    //       role: (number && number.toUpperCase().startsWith('A')) ? 'lecturer' : 'student'
+    //     }
 
+    req.session.userId = number
+    req.session.userName = fullName
+    req.session.userRole = role
+
+    req.session.showWelcome = true
     // Database Insertion
     if (role === 'lecturer') {
       const stmt = db.prepare(`
@@ -54,7 +59,6 @@ const registerUser = (req, res) => {
         error: null,
         redirectTo: '/lecturer/courses'
       })
-
     } else {
       const stmt = db.prepare(`
         INSERT INTO students (student_number, name, email, password, degree_code)
@@ -67,7 +71,6 @@ const registerUser = (req, res) => {
         error: null,
         redirectTo: '/student/courses'
       })
-
     }
   } catch (error) {
     console.error('Signup error:', error)

--- a/src/controllers/signup-controller.js
+++ b/src/controllers/signup-controller.js
@@ -29,11 +29,6 @@ const registerUser = (req, res) => {
       return res.render('sign-up', { message: null, error: 'Please use your Wits email address.' })
     }
 
-    req.session.userId = number
-    req.session.userName = fullName
-    req.session.userRole = role
-
-    req.session.showWelcome = true
     // Database Insertion
     if (role === 'lecturer') {
       const stmt = db.prepare(`
@@ -41,6 +36,11 @@ const registerUser = (req, res) => {
         VALUES (?, ?, ?, ?, ?, ?)
       `)
       stmt.run(number, fullName, email, 'EIE', 'EIE', password) // EIE are just place holders
+
+      req.session.userId = number
+      req.session.userName = fullName
+      req.session.userRole = 'lecturer'
+      req.session.showWelcome = true
 
       return res.render('sign-up', {
         message: 'Account created! Redirecting you to select your courses...',
@@ -53,6 +53,11 @@ const registerUser = (req, res) => {
         VALUES (?, ?, ?, ?, ?)
       `)
       stmt.run(parseInt(number), fullName, email, password, 'BSCENGINFO') // degree code is just a placeholder
+
+      req.session.userId = parseInt(number)
+      req.session.userName = fullName
+      req.session.userRole = 'student'
+      req.session.showWelcome = true
 
       return res.render('sign-up', {
         message: 'Account created! Redirecting you to select your courses...',

--- a/src/controllers/signup-controller.js
+++ b/src/controllers/signup-controller.js
@@ -29,18 +29,6 @@ const registerUser = (req, res) => {
       return res.render('sign-up', { message: null, error: 'Please use your Wits email address.' })
     }
 
-    // const user = req.session && req.session.userId
-    //   ? {
-    //       id: req.session.userId,
-    //       name: req.session.userName,
-    //       role: req.session.userRole
-    //     }
-    //   : {
-    //       id: number,
-    //       name: fullName,
-    //       role: (number && number.toUpperCase().startsWith('A')) ? 'lecturer' : 'student'
-    //     }
-
     req.session.userId = number
     req.session.userName = fullName
     req.session.userRole = role
@@ -82,7 +70,7 @@ const registerUser = (req, res) => {
   }
 }
 
-// Explicitly export these functions
+// Export these functions
 module.exports = {
   showSignupPage,
   registerUser

--- a/tests/unit/signup-controller.test.js
+++ b/tests/unit/signup-controller.test.js
@@ -30,17 +30,22 @@ describe('email domain validation', () => {
       password: 'pass',
       confirmPassword: 'pass'
     })
+    req.session = {}
 
     const res = mockRes()
     registerUser(req, res)
 
+    expect(req.session.userId).toBe(1234567)
+    expect(req.session.userName).toBe('Test Student')
+    expect(req.session.userRole).toBe('student')
+    expect(req.session.showWelcome).toBe(true)
     expect(res.render).toHaveBeenCalledWith(
       'sign-up',
-      expect.objectContaining({
+      {
         message: 'Account created! Redirecting you to select your courses...',
         error: null,
         redirectTo: '/student/courses'
-      })
+      }
     )
   })
 
@@ -54,10 +59,15 @@ describe('email domain validation', () => {
       password: 'pass',
       confirmPassword: 'pass'
     })
+    req.session = {}
 
     const res = mockRes()
     registerUser(req, res)
 
+    expect(req.session.userId).toBe('A000999')
+    expect(req.session.userName).toBe('Test Lecturer')
+    expect(req.session.userRole).toBe('lecturer')
+    expect(req.session.showWelcome).toBe(true)
     expect(res.render).toHaveBeenCalledWith(
       'sign-up',
       expect.objectContaining({

--- a/tests/unit/signup-greeting.test.js
+++ b/tests/unit/signup-greeting.test.js
@@ -31,6 +31,7 @@ describe('Sign Up greeting validation', () => {
       password: 'pass',
       confirmPassword: 'pass'
     })
+    req.session = {}
 
     const res = mockRes()
 
@@ -56,6 +57,7 @@ describe('Sign Up greeting validation', () => {
       password: 'pass',
       confirmPassword: 'pass'
     })
+    req.session = {}
 
     const res = mockRes()
 


### PR DESCRIPTION
close #68 Implement login after signup

# Overview
Automatically log in users after successful signup and redirect them to their respective dashboards (student or lecturer). 

After this 
- Lecturers are redirected to the lecturer dashboard with the welcome message activated.
- Students are redirected to the student dashboard with the welcome message activated.

## Changes Made
- User name, role and ID are saved for middleware use between pages.

## Tests
- No tests were added for this small change
- Outdated test were updated