### PR TITLE
Feature/course discovery and lecturer polish

### DIFF
--- a/database/seedVitalInfo.sql
+++ b/database/seedVitalInfo.sql
@@ -310,5 +310,5 @@ INSERT OR IGNORE INTO admins (admin_id, name, email, password) VALUES
 INSERT OR IGNORE INTO lecturer_availability (availability_id, staff_number, day_of_week, start_time, end_time, max_booking_min, max_number_of_students, venue) VALUES
   ('1', 'A000356', 'Mon', '10:00', '11:00', 60, 5, 'Room 101'),
   ('2', 'A000357', 'Tue', '11:00', '13:00', 120, 10, 'Room 102'),
-  ('3', 'A000356', 'Wed', '10:00', '14:00', 180, 11, 'Room 103'),
+  ('3', 'A000356', 'Wed', '10:00', '14:00', 180, 10, 'Room 103'),
   ('4', 'A000357', 'Thu', '11:00', '14:00', 120, 6, 'Room 104');

--- a/documentation/user_story_map.usm
+++ b/documentation/user_story_map.usm
@@ -19,6 +19,7 @@ KnockKnock.prof User Story Map: |{"bg":"#266B9A"}
             Cancel availability (3 pts)
             Set max consultations duration per day (2 pts)
             Lecturer can add courses they teach and the department they are in (5 pts): |{"font_size":10}
+            Display assigned courses on lecturer dashboard (3 pts)
                 Cancel consultations (3 pts)
                     Flag a student if they ding door dash (2 pts)
     Book and manage consultations

--- a/src/controllers/availability-controller.js
+++ b/src/controllers/availability-controller.js
@@ -26,6 +26,13 @@ const saveAvailability = (req, res) => {
     });
   }
 
+  if (Number(max_number_of_students) < 1 || Number(max_number_of_students) > 10) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: 'Max students must be between 1 and 10.', success: null
+    });
+  }
+
   if (!isBusinessHours(start_time, end_time)) {
     return res.render('availability', {
       user, availability: getAvailability(user.id),

--- a/src/controllers/availability-controller.js
+++ b/src/controllers/availability-controller.js
@@ -17,9 +17,9 @@ const showAvailability = (req, res) => {
 
 const saveAvailability = (req, res) => {
   const user = { id: req.session.userId, name: req.session.userName, role: req.session.userRole };
-  const { day_of_week, start_time, end_time, venue, max_number_of_students } = req.body;
+  const { day_of_week, start_time, end_time, venue, max_number_of_students, max_booking_min } = req.body;
 
-  if (!validateSlotFields({ day_of_week, start_time, end_time, venue, max_number_of_students })) {
+  if (!validateSlotFields({ day_of_week, start_time, end_time, venue, max_number_of_students, max_booking_min })) {
     return res.render('availability', {
       user, availability: getAvailability(user.id),
       error: 'All fields are required.', success: null
@@ -47,8 +47,8 @@ const saveAvailability = (req, res) => {
   }
 
   db.prepare(
-    'INSERT INTO lecturer_availability (staff_number, day_of_week, start_time, end_time, venue, max_number_of_students) VALUES (?, ?, ?, ?, ?, ?)'
-  ).run(user.id, day_of_week, start_time, end_time, venue, Number(max_number_of_students));
+    'INSERT INTO lecturer_availability (staff_number, day_of_week, start_time, end_time, venue, max_number_of_students, max_booking_min) VALUES (?, ?, ?, ?, ?, ?, ?)'
+  ).run(user.id, day_of_week, start_time, end_time, venue, Number(max_number_of_students), Number(max_booking_min));
 
   return res.render('availability', {
     user, availability: getAvailability(user.id),

--- a/src/controllers/lecturer-dashboard-controller.js
+++ b/src/controllers/lecturer-dashboard-controller.js
@@ -65,7 +65,7 @@ const showLecturerDashboard = (req, res) => {
       stats,
       calendar,
       assignedCourses,
-      success: showWelcome ? welcomeMessage : (req.query.success || null),
+      success: showWelcome ? welcomeMessage : (req.query.success === 'true' ? 'Courses updated successfully.' : null),
       error: null,
     });
 

--- a/src/controllers/lecturer-dashboard-controller.js
+++ b/src/controllers/lecturer-dashboard-controller.js
@@ -48,6 +48,15 @@ const showLecturerDashboard = (req, res) => {
     };
 
     const calendar = buildCalendar(user.id);
+
+    const assignedCourses = db.prepare(`
+      SELECT c.course_code, c.course_name, c.year_level, c.dept_code
+      FROM staff_courses sc
+      JOIN courses c ON sc.course_code = c.course_code
+      WHERE sc.staff_number = ?
+      ORDER BY c.year_level, c.course_code
+    `).all(user.id) || [];
+
     const welcomeMessage = `Welcome back, Prof. ${user.name}! Ready for your consultations?`;
 
     return res.render('lecturer-dashboard', {
@@ -55,6 +64,7 @@ const showLecturerDashboard = (req, res) => {
       upcomingConsultations: upcomingRows,
       stats,
       calendar,
+      assignedCourses,
       success: showWelcome ? welcomeMessage : (req.query.success || null),
       error: null,
     });
@@ -66,6 +76,7 @@ const showLecturerDashboard = (req, res) => {
       upcomingConsultations: [],
       stats:    { daysAvailable: 0, hoursAvailable: 0, totalSlots: 0 },
       calendar: buildCalendar(null),
+      assignedCourses: [],
       error:   'Could not load dashboard data. Please try again.',
       success:  null,
     });

--- a/src/services/availability-helpers.js
+++ b/src/services/availability-helpers.js
@@ -3,8 +3,8 @@ const generateConstId = (date, count) => {
   return `${date}-${sequence}`;
 };
 
-const validateSlotFields = ({ day_of_week, start_time, end_time, venue, max_number_of_students }) => {
-  return !!(day_of_week && start_time && end_time && venue && max_number_of_students);
+const validateSlotFields = ({ day_of_week, start_time, end_time, venue, max_number_of_students, max_booking_min }) => {
+  return !!(day_of_week && start_time && end_time && venue && max_number_of_students && max_booking_min);
 };
 
 const toMinutes = (timeStr) => {

--- a/src/views/availability.html
+++ b/src/views/availability.html
@@ -70,6 +70,13 @@
             </div>
 
             <div class="mb-3">
+              <label for="max_booking_min" class="form-label fw-semibold">Max Consultation Duration (minutes)</label>
+              <input type="number" class="form-control" id="max_booking_min" name="max_booking_min"
+                min="15" max="480" value="60" required>
+              <div class="form-text">How long each individual consultation can last within this window.</div>
+            </div>
+
+            <div class="mb-3">
               <label for="venue" class="form-label fw-semibold">Venue</label>
               <input type="text" class="form-control" id="venue" name="venue"
                 placeholder="e.g. Room 101 or https://meet.link" required>

--- a/src/views/availability.html
+++ b/src/views/availability.html
@@ -108,7 +108,8 @@
                     <th scope="col">Start</th>
                     <th scope="col">End</th>
                     <th scope="col">Venue</th>
-                    <th scope="col">Max</th>
+                    <th scope="col">Max Students</th>
+                    <th scope="col">Consult (min)</th>
                     <th scope="col"></th>
                   </tr>
                 </thead>
@@ -120,6 +121,7 @@
                       <td class="text-nowrap"><%= slot.end_time %></td>
                       <td><%= slot.venue %></td>
                       <td><%= slot.max_number_of_students %></td>
+                      <td><%= slot.max_booking_min %></td>
                       <td>
                         <form action="/lecturer/availability/<%= slot.availability_id %>/delete" method="POST" class="d-inline">
                           <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>

--- a/src/views/lecturer-courses.html
+++ b/src/views/lecturer-courses.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><%= onboarding ? 'Course Selection' : 'Edit Courses' %></title>
+  <title><%= onboarding ? 'Course Selection' : 'Courses I Teach' %></title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
     body { background: #f5f7fb; }
@@ -28,12 +28,12 @@
   </header>
 
   <main class="container p-4">
-    <h2><%= onboarding ? 'Welcome! Select Your Courses' : 'Edit Your Courses' %></h2>
+    <h2><%= onboarding ? 'Welcome! Select Your Courses' : 'Courses I Teach' %></h2>
     <p class="text-muted">
       <% if (onboarding) { %>
         Please select your department and the courses you are teaching.
       <% } else { %>
-        Update your department and courses below.
+        Manage the courses you are currently consulting for. Students enrolled in these courses will be able to book consultations with you.
       <% } %>
     </p>
 
@@ -66,7 +66,7 @@
           <h5 class="mb-0">Courses</h5>
           <div class="d-flex align-items-center gap-3">
             <span class="badge bg-secondary fs-6" id="course-count">0 selected</span>
-            <button type="submit" class="btn btn-primary btn-sm">Save Courses</button>
+            <button type="submit" class="btn btn-primary btn-sm"><%= onboarding ? 'Save Courses' : 'Update Teaching Load' %></button>
           </div>
         </div>
         <input
@@ -79,7 +79,7 @@
         <div id="courses-wrapper"></div>
       </div>
 
-      <button type="submit" class="btn btn-primary px-4">Save Courses</button>
+      <button type="submit" class="btn btn-primary px-4"><%= onboarding ? 'Save Courses' : 'Update Teaching Load' %></button>
     </form>
   </main>
 

--- a/src/views/lecturer-courses.html
+++ b/src/views/lecturer-courses.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title><%= onboarding ? 'Course Selection' : 'Courses I Teach' %></title>
+  <title><%= onboarding ? 'Course Selection' : 'My Courses' %></title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
     body { background: #f5f7fb; }
@@ -28,7 +28,7 @@
   </header>
 
   <main class="container p-4">
-    <h2><%= onboarding ? 'Welcome! Select Your Courses' : 'Courses I Teach' %></h2>
+    <h2><%= onboarding ? 'Welcome! Select Your Courses' : 'My Courses' %></h2>
     <p class="text-muted">
       <% if (onboarding) { %>
         Please select your department and the courses you are teaching.

--- a/src/views/lecturer-dashboard.html
+++ b/src/views/lecturer-dashboard.html
@@ -26,6 +26,8 @@
     .calendar-table .today { background-color: dodgerblue; color: white; font-weight: bold; }
     .calendar-table .has-consultation { background-color: #d1e7dd; font-weight: 600; }
     .calendar-table .empty { background-color: transparent; border: none; }
+    .course-card { border-radius: 12px; }
+    .course-card.border-default { border: 1px solid #dee2e6 !important; }
   </style>
 </head>
 <body>
@@ -71,6 +73,40 @@
             </div>
           </div>
           <a href="/lecturer/availability" class="btn btn-primary btn-sm mt-2">Set Availability</a>
+        </div>
+
+        <div class="card p-4 mt-4">
+          <div class="d-flex justify-content-between align-items-center mb-3">
+            <h4 class="mb-0">My Courses</h4>
+            <a href="/lecturer/courses" class="btn btn-sm btn-outline-primary">Edit</a>
+          </div>
+          <% if (assignedCourses.length === 0) { %>
+            <p class="text-muted mb-2">You haven't added any courses yet. Students won't be able to book consultations with you until you add at least one course.</p>
+            <a href="/lecturer/courses" class="btn btn-primary btn-sm">Add Courses</a>
+          <% } else { %>
+            <%
+              const yearLevels = [1, 2, 3, 4];
+            %>
+            <% yearLevels.forEach(year => { %>
+              <% const yearCourses = assignedCourses.filter(c => c.year_level === year); %>
+              <% if (yearCourses.length > 0) { %>
+                <p class="text-muted small mb-2 mt-3">Year <%= year %></p>
+                <div class="row g-2">
+                  <% yearCourses.forEach(c => { %>
+                    <div class="col-md-6 col-lg-4">
+                      <div class="card course-card border-default p-3 h-100">
+                        <div class="fw-semibold"><%= c.course_code %></div>
+                        <div class="text-muted small"><%= c.course_name %></div>
+                        <div class="mt-1">
+                          <span class="badge bg-secondary bg-opacity-10 text-secondary small"><%= c.dept_code %></span>
+                        </div>
+                      </div>
+                    </div>
+                  <% }); %>
+                </div>
+              <% } %>
+            <% }); %>
+          <% } %>
         </div>
 
         <div class="card p-4 mt-4">

--- a/tests/e2e/lecturer-dashboard.spec.js
+++ b/tests/e2e/lecturer-dashboard.spec.js
@@ -1,0 +1,14 @@
+const { test, expect } = require('@playwright/test');
+
+test('lecturer dashboard shows My Courses section with seeded course after login', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('[name="staffStudentNumber"]', 'A000356');
+  await page.fill('[name="password"]', 'pass');
+  await page.click('[type="submit"]');
+
+  await page.waitForURL('**/lecturer/dashboard');
+
+  await expect(page.getByText('My Courses')).toBeVisible();
+  await expect(page.getByText('ELEN4010')).toBeVisible();
+  await expect(page.locator('a[href="/lecturer/courses"]').first()).toBeVisible();
+});

--- a/tests/e2e/lecturer-dashboard.spec.js
+++ b/tests/e2e/lecturer-dashboard.spec.js
@@ -6,7 +6,7 @@ test('lecturer dashboard shows My Courses section with seeded course after login
   await page.fill('[name="password"]', 'pass');
   await page.click('[type="submit"]');
 
-  await page.waitForURL('**/lecturer/dashboard');
+  await page.waitForURL('**/lecturer/dashboard**');
 
   await expect(page.getByText('My Courses')).toBeVisible();
   await expect(page.getByText('ELEN4010')).toBeVisible();

--- a/tests/integration/lecturerDashboard.test.js
+++ b/tests/integration/lecturerDashboard.test.js
@@ -17,4 +17,20 @@ describe('GET /lecturer/dashboard', () => {
     expect(res.text).toContain('Lecturer Dashboard');
     expect(res.text).toContain('Upcoming Consultations');
   });
+
+  test('renders My Courses section when authenticated as a lecturer', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: 'A000356', password: 'pass' });
+    const res = await agent.get('/lecturer/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('My Courses');
+  });
+
+  test('renders seeded course code ELEN4010 on the dashboard for lecturer A000356', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: 'A000356', password: 'pass' });
+    const res = await agent.get('/lecturer/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('ELEN4010');
+  });
 });

--- a/tests/unit/availability-controller.test.js
+++ b/tests/unit/availability-controller.test.js
@@ -83,7 +83,7 @@ describe('saveAvailability', () => {
 
     saveAvailability(mockReq({ body: validBody }), mockRes());
 
-    expect(runFn).toHaveBeenCalledWith('A000356', 'Mon', '09:00', '10:00', 'Room 1', 1);
+    expect(runFn).toHaveBeenCalledWith('A000356', 'Mon', '09:00', '10:00', 'Room 1', 1, 60);
   });
 
   test('renders error when required fields are missing', () => {
@@ -109,6 +109,18 @@ describe('saveAvailability', () => {
     expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
       error: expect.stringContaining('08:00 and 18:00'),
       success: null
+    }));
+  });
+
+  test('renders error when max_number_of_students exceeds 10', () => {
+    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) });
+
+    const req = mockReq({ body: { ...validBody, max_number_of_students: '11' } });
+    const res = mockRes();
+    saveAvailability(req, res);
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: 'Max students must be between 1 and 10.'
     }));
   });
 

--- a/tests/unit/availability-controller.test.js
+++ b/tests/unit/availability-controller.test.js
@@ -55,7 +55,7 @@ describe('showAvailability', () => {
 describe('saveAvailability', () => {
   const validBody = {
     day_of_week: 'Mon', start_time: '09:00', end_time: '10:00',
-    venue: 'Room 1', max_number_of_students: '1'
+    venue: 'Room 1', max_number_of_students: '1', max_booking_min: '60'
   };
 
   test('saves slot and renders success when all fields are valid and no overlap', () => {

--- a/tests/unit/availability-helpers.test.js
+++ b/tests/unit/availability-helpers.test.js
@@ -21,7 +21,8 @@ describe('validateSlotFields()', () => {
       start_time: '09:00',
       end_time: '10:00',
       venue: 'Room 1',
-      max_number_of_students: '5'
+      max_number_of_students: '5',
+      max_booking_min: '60'
     })).toBe(true);
   });
 

--- a/tests/unit/dashboard-controller.test.js
+++ b/tests/unit/dashboard-controller.test.js
@@ -30,6 +30,7 @@ describe('showLecturerDashboard()', () => {
     ];
     db.prepare
       .mockReturnValueOnce({ all: jest.fn().mockReturnValue(rows) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
       .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) });
 
     const res = mockRes();
@@ -46,6 +47,7 @@ describe('showLecturerDashboard()', () => {
     ];
     db.prepare
       .mockReturnValueOnce({ all: jest.fn().mockReturnValue(rows) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
       .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) });
 
     const res = mockRes();
@@ -69,6 +71,64 @@ describe('showLecturerDashboard()', () => {
       upcomingConsultations: [],
       stats: { daysAvailable: 0, hoursAvailable: 0, totalSlots: 0 },
       error: 'Could not load dashboard data. Please try again.',
+    }));
+  });
+
+  test('passes assignedCourses to the view when the lecturer has courses', () => {
+    const courses = [
+      { course_code: 'ELEN4010', course_name: 'Software Dev', year_level: 4, dept_code: 'ELEN' },
+      { course_code: 'ELEN3009', course_name: 'Signals', year_level: 3, dept_code: 'ELEN' },
+    ];
+    db.prepare
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(courses) });
+
+    const res = mockRes();
+    showLecturerDashboard(mockReq(), res);
+
+    expect(res.render).toHaveBeenCalledWith('lecturer-dashboard', expect.objectContaining({
+      assignedCourses: courses,
+    }));
+  });
+
+  test('passes assignedCourses as empty array when the lecturer has no courses', () => {
+    db.prepare
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) });
+
+    const res = mockRes();
+    showLecturerDashboard(mockReq(), res);
+
+    expect(res.render).toHaveBeenCalledWith('lecturer-dashboard', expect.objectContaining({
+      assignedCourses: [],
+    }));
+  });
+
+  test('calls the assigned-courses query with the correct staff_number from the session', () => {
+    const coursesQuery = jest.fn().mockReturnValue([]);
+    db.prepare
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+      .mockReturnValueOnce({ all: coursesQuery });
+
+    showLecturerDashboard(mockReq(), mockRes());
+
+    expect(coursesQuery).toHaveBeenCalledWith('A000356');
+  });
+
+  test('includes assignedCourses as empty array in the error render when the DB throws', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    db.prepare.mockReturnValue({
+      all: jest.fn().mockImplementation(() => { throw new Error('DB failure'); })
+    });
+
+    const res = mockRes();
+    showLecturerDashboard(mockReq(), res);
+
+    expect(res.render).toHaveBeenCalledWith('lecturer-dashboard', expect.objectContaining({
+      assignedCourses: [],
     }));
   });
 });


### PR DESCRIPTION
Closes #69 

## Summary

Adds a "My Courses" section to the lecturer dashboard so that lecturers can see which courses they are currently teaching at a glance, and tweaks the copy on `/lecturer/courses` to reflect its dual role as both an onboarding page and an editing page.

## Changes

**Lecturer dashboard now displays assigned courses**
- New query in `lecturer-dashboard-controller.js` joining `staff_courses` and `courses` to fetch the lecturer's teaching load
- New "My Courses" card on `lecturer-dashboard.html`, placed between Availability Overview and Upcoming Consultations
- Courses are grouped by year level and display course code, name, and department badge — mirroring the student dashboard pattern for consistency
- Empty state guides newly-signed-up lecturers to add courses before students can book

**Copy refinements on `/lecturer/courses`**
- Heading changes from "Edit Your Courses" to "Courses I Teach" outside onboarding
- Description rewritten to frame the page around managing teaching load rather than initial setup
- Save buttons relabelled "Update Teaching Load" in editing context
- Onboarding flow copy unchanged

**Test coverage**
- Four new unit tests in `dashboard-controller.test.js` covering assigned courses being passed to the view, empty state, correct staff number being used in the query, and the error path
- New integration test in `lecturerDashboard.test.js` asserting the My Courses section renders with seeded course data
- New Playwright E2E spec `lecturer-dashboard.spec.js` covering the full login → dashboard → My Courses visibility flow

**Documentation**
- User story map updated with the new developer story under the lecturer course management epic

## Acceptance tests

- [x] Logging in as A000356 shows ELEN4010 and ELEN3009 grouped by year on the dashboard
- [x] Clicking "Edit" on the My Courses card navigates to `/lecturer/courses`
- [x] A lecturer with no assigned courses sees the empty-state guidance
- [x] Heading on `/lecturer/courses` reads "Courses I Teach" when not onboarding
- [x] All existing tests continue to pass
- [x] New unit, integration, and E2E tests pass locally and in CI

## Notes for reviewer

- This is the third sub-issue under #6 (Lecturer course management) and slots in alongside #44 and #45
- Per-course consultation counts were considered but deferred — we don't yet have real consultation data, and the dashboard would mislead lecturers if it always showed "0 upcoming". A future story will add this once consultations are bookable.
- Cross-browser E2E remains Chromium-only per ADR-009

Closes #69