### PR TITLE
Feat/admin search

### DIFF
--- a/src/controllers/admin-controller.js
+++ b/src/controllers/admin-controller.js
@@ -1,4 +1,5 @@
 const db = require('../../database/db');
+const { buildSearchQuery } = require('../services/admin-helpers');
 
 const PAGE_SIZE = 20;
 
@@ -13,7 +14,7 @@ const showAdminDashboard = (req, res) => {
   const tables = getAllTables();
   res.render('admin-dashboard', {
     user, tables,
-    activeTable: null, columns: [], rows: [], page: 1, totalPages: 1,
+    activeTable: null, columns: [], rows: [], page: 1, totalPages: 1, totalRows: 0, search: '',
     error: null, success: null,
   });
 };
@@ -27,14 +28,24 @@ const showTable = (req, res) => {
 
   const page = Math.max(1, parseInt(req.query.page) || 1);
   const offset = (page - 1) * PAGE_SIZE;
-  const totalRows = db.prepare(`SELECT COUNT(*) as count FROM "${tableName}"`).get().count;
-  const totalPages = Math.max(1, Math.ceil(totalRows / PAGE_SIZE));
-  const rows = db.prepare(`SELECT rowid, * FROM "${tableName}" LIMIT ? OFFSET ?`).all(PAGE_SIZE, offset);
+  const search = (req.query.search || '').trim();
   const columns = getColumns(tableName);
+
+  let totalRows, rows;
+  if (search) {
+    const { whereClauses, params } = buildSearchQuery(columns, search);
+    totalRows = db.prepare(`SELECT COUNT(*) as count FROM "${tableName}" WHERE ${whereClauses}`).get(...params).count;
+    rows = db.prepare(`SELECT rowid, * FROM "${tableName}" WHERE ${whereClauses} LIMIT ? OFFSET ?`).all(...params, PAGE_SIZE, offset);
+  } else {
+    totalRows = db.prepare(`SELECT COUNT(*) as count FROM "${tableName}"`).get().count;
+    rows = db.prepare(`SELECT rowid, * FROM "${tableName}" LIMIT ? OFFSET ?`).all(PAGE_SIZE, offset);
+  }
+
+  const totalPages = Math.max(1, Math.ceil(totalRows / PAGE_SIZE));
 
   res.render('admin-dashboard', {
     user, tables,
-    activeTable: tableName, columns, rows, page, totalPages,
+    activeTable: tableName, columns, rows, page, totalPages, totalRows, search,
     error: req.query.error || null,
     success: req.query.success || null,
   });
@@ -60,7 +71,7 @@ const createRecord = (req, res) => {
     const rows = db.prepare(`SELECT rowid, * FROM "${tableName}" LIMIT ?`).all(PAGE_SIZE);
     res.render('admin-dashboard', {
       user: { id: req.session.userId, name: req.session.userName },
-      tables, activeTable: tableName, columns, rows, page: 1, totalPages,
+      tables, activeTable: tableName, columns, rows, page: 1, totalPages, totalRows, search: '',
       error: err.message, success: null,
     });
   }

--- a/src/controllers/admin-controller.js
+++ b/src/controllers/admin-controller.js
@@ -94,6 +94,7 @@ const deleteRecord = (req, res) => {
   const tables = getAllTables();
   const { tableName, rowId } = req.params;
   if (!tables.includes(tableName)) return res.status(404).send('Table not found');
+  if (tableName === 'admins') return res.redirect('/admin/table/admins?error=Admin+accounts+cannot+be+deleted');
 
   try {
     db.prepare(`DELETE FROM "${tableName}" WHERE rowid = ?`).run(rowId);

--- a/src/services/admin-helpers.js
+++ b/src/services/admin-helpers.js
@@ -1,0 +1,7 @@
+const buildSearchQuery = (columns, searchTerm) => {
+  const whereClauses = columns.map(c => `"${c.name}" LIKE ?`).join(' OR ');
+  const params = columns.map(() => `%${searchTerm}%`);
+  return { whereClauses, params };
+};
+
+module.exports = { buildSearchQuery };

--- a/src/views/admin-dashboard.html
+++ b/src/views/admin-dashboard.html
@@ -90,8 +90,10 @@ function formatCol(name) {
                       <button class="btn btn-outline-primary btn-sm me-1 edit-btn"
                         data-row="<%= JSON.stringify(row) %>"
                         data-rowid="<%= row.rowid %>">Edit</button>
+                      <% if (activeTable !== 'admins') { %>
                       <button class="btn btn-outline-danger btn-sm delete-btn"
                         data-rowid="<%= row.rowid %>">Delete</button>
+                      <% } %>
                     </td>
                   </tr>
                 <% }); %>

--- a/src/views/admin-dashboard.html
+++ b/src/views/admin-dashboard.html
@@ -69,6 +69,18 @@ function formatCol(name) {
           <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#addModal">+ Add Record</button>
         </div>
 
+        <form class="d-flex gap-2 mb-2" method="GET" action="/admin/table/<%= activeTable %>">
+          <input type="text" class="form-control form-control-sm" name="search"
+            value="<%= search %>" placeholder="Search all columns...">
+          <button type="submit" class="btn btn-primary btn-sm px-3">Search</button>
+          <% if (search) { %>
+            <a href="/admin/table/<%= activeTable %>" class="btn btn-outline-secondary btn-sm">Clear</a>
+          <% } %>
+        </form>
+        <% if (search) { %>
+          <p class="text-muted small mb-2"><%= totalRows %> result<%= totalRows !== 1 ? 's' : '' %> for "<%= search %>"</p>
+        <% } %>
+
         <div class="bg-white rounded-3 shadow-sm mb-3">
           <div class="table-responsive">
             <table class="table table-hover table-sm mb-0">
@@ -99,7 +111,7 @@ function formatCol(name) {
                 <% }); %>
                 <% if (rows.length === 0) { %>
                   <tr>
-                    <td colspan="<%= columns.length + 1 %>" class="text-center text-muted py-4">No records in this table</td>
+                    <td colspan="<%= columns.length + 1 %>" class="text-center text-muted py-4"><%= search ? 'No records match your search.' : 'No records in this table.' %></td>
                   </tr>
                 <% } %>
               </tbody>
@@ -111,13 +123,13 @@ function formatCol(name) {
           <nav>
             <ul class="pagination pagination-sm">
               <li class="page-item <%= page <= 1 ? 'disabled' : '' %>">
-                <a class="page-link" href="?page=<%= page - 1 %>">Previous</a>
+                <a class="page-link" href="?page=<%= page - 1 %><%= search ? '&search=' + encodeURIComponent(search) : '' %>">Previous</a>
               </li>
               <li class="page-item disabled">
                 <span class="page-link"><%= page %> / <%= totalPages %></span>
               </li>
               <li class="page-item <%= page >= totalPages ? 'disabled' : '' %>">
-                <a class="page-link" href="?page=<%= page + 1 %>">Next</a>
+                <a class="page-link" href="?page=<%= page + 1 %><%= search ? '&search=' + encodeURIComponent(search) : '' %>">Next</a>
               </li>
             </ul>
           </nav>

--- a/tests/unit/admin-controller.test.js
+++ b/tests/unit/admin-controller.test.js
@@ -55,9 +55,9 @@ describe('showTable', () => {
   test('renders table data for a valid table name', () => {
     db.prepare
       .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })
       .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ count: 1 }) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(ROWS) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) });
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(ROWS) });
 
     const req = mockReq({ params: { tableName: 'admins' }, query: {} });
     const res = mockRes();
@@ -70,6 +70,26 @@ describe('showTable', () => {
       rows: ROWS,
       page: 1,
       totalPages: 1,
+      search: '',
+    }));
+  });
+
+  test('filters rows using SQL LIKE when a search term is provided', () => {
+    db.prepare
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ count: 1 }) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(ROWS) });
+
+    const req = mockReq({ params: { tableName: 'admins' }, query: { search: 'Admin' } });
+    const res = mockRes();
+
+    showTable(req, res);
+
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining('LIKE'));
+    expect(res.render).toHaveBeenCalledWith('admin-dashboard', expect.objectContaining({
+      search: 'Admin',
+      activeTable: 'admins',
     }));
   });
 
@@ -169,12 +189,23 @@ describe('deleteRecord', () => {
       .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
       .mockReturnValueOnce({ run: jest.fn() });
 
+    const req = mockReq({ params: { tableName: 'courses', rowId: '1' } });
+    const res = mockRes();
+
+    deleteRecord(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith('/admin/table/courses?success=Record+deleted');
+  });
+
+  test('blocks deletion of admin accounts', () => {
+    db.prepare.mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) });
+
     const req = mockReq({ params: { tableName: 'admins', rowId: '1' } });
     const res = mockRes();
 
     deleteRecord(req, res);
 
-    expect(res.redirect).toHaveBeenCalledWith('/admin/table/admins?success=Record+deleted');
+    expect(res.redirect).toHaveBeenCalledWith('/admin/table/admins?error=Admin+accounts+cannot+be+deleted');
   });
 
   test('redirects with error when a foreign key constraint prevents deletion', () => {

--- a/tests/unit/admin-helpers.test.js
+++ b/tests/unit/admin-helpers.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+const { buildSearchQuery } = require('../../src/services/admin-helpers');
+
+const COLUMNS = [
+  { name: 'admin_id', pk: 1 },
+  { name: 'name',     pk: 0 },
+  { name: 'email',    pk: 0 },
+];
+
+describe('buildSearchQuery', () => {
+  test('builds a LIKE clause for every column', () => {
+    const { whereClauses } = buildSearchQuery(COLUMNS, 'test');
+    expect(whereClauses).toBe('"admin_id" LIKE ? OR "name" LIKE ? OR "email" LIKE ?');
+  });
+
+  test('wraps the search term in % wildcards for each column', () => {
+    const { params } = buildSearchQuery(COLUMNS, 'test');
+    expect(params).toEqual(['%test%', '%test%', '%test%']);
+  });
+
+  test('produces one param entry per column', () => {
+    const { params } = buildSearchQuery(COLUMNS, 'x');
+    expect(params).toHaveLength(COLUMNS.length);
+  });
+});


### PR DESCRIPTION
Related #5 
Closes #84  

## What Was Changed

### Admin Search

- Added a search input above the admin table view.
- Search now sends a `GET` request to the existing table route using a `search` query parameter.
- The admin controller builds a SQL `LIKE` query across all visible columns for the selected table.
- Matching records are returned from the database and displayed in the table.
- Non-matching records are excluded from the returned result set.
- Clearing the search reloads the table with all records.
- Pagination links preserve the search term across pages.
- Empty search results now show a distinct message from an empty table.

### Search Helper

- Extracted `buildSearchQuery` into `src/services/admin-helpers.js`.
- The helper constructs the `WHERE` clause and parameter list using column definitions returned by `PRAGMA table_info`.
- Table and column names come from trusted schema sources and are not taken directly from user input, which helps prevent SQL injection.

### Admin Account Protection

- Removed the `Delete` button from the `Admins` table in the UI.
- Added a server-side guard in `deleteRecord` to block deletion of admin accounts, even if the route is called directly.

## Why It Was Changed

This addresses the admin search user story.

Admins managing large tables need to locate specific records quickly without scrolling through paginated results. A dedicated full-text search service is not needed at this scale, so the implementation uses SQL `LIKE` queries against SQLite, which is appropriate for the current dataset size.

## Testing

Tests cover the following:

- `buildSearchQuery` produces the correct `WHERE` clause for a given set of columns.
- `buildSearchQuery` wraps the search term in percent wildcards for each column.
- `showTable` passes the search term through to the rendered view.
- `showTable` uses a `LIKE` query when a search term is provided.
- `deleteRecord` blocks deletion of admin accounts and redirects with an error.