### PR TITLE
Booking consultation

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,8 @@ const availabilityRoutes = require('./src/routes/availability-routes')
 const studentCoursesRoutes = require('./src/routes/student-courses-routes')
 const lecturerCoursesRoutes = require('./src/routes/lecturer-courses-routes')
 const adminRoutes = require('./src/routes/admin-routes')
+const courseRoutes = require('./src/routes/course-routes')
+const consultationRoutes = require('./src/routes/consultation-routes')
 
 const app = express()
 const PORT = process.env.PORT || 3000
@@ -40,6 +42,8 @@ app.use('/', availabilityRoutes)
 app.use('/', studentCoursesRoutes)
 app.use('/', lecturerCoursesRoutes)
 app.use('/', adminRoutes)
+app.use('/', courseRoutes)
+app.use('/', consultationRoutes)
 
 app.get('/', (req, res) => {
   const user = req.session && req.session.userId

--- a/database/createSchema.sql
+++ b/database/createSchema.sql
@@ -78,13 +78,16 @@ CREATE TABLE consultations (
   consultation_time        TEXT NOT NULL CHECK (consultation_time GLOB '[0-9][0-9]:[0-9][0-9]'),
   lecturer_id              TEXT,
   organiser                INTEGER,
+  availability_id          INTEGER,
   duration_min             INTEGER NOT NULL DEFAULT 60 CHECK (duration_min > 0 AND duration_min <= 480),
   max_number_of_students   INTEGER NOT NULL DEFAULT 1 CHECK (max_number_of_students > 0),
   venue                    TEXT NOT NULL CHECK(length(venue) >= 3),
   status                   TEXT NOT NULL DEFAULT 'Available' CHECK (status IN ('Available', 'Booked', 'Ongoing', 'Missed', 'Cancelled', 'Rescheduled', 'RescheduledToNow')),
+  allow_join               INTEGER NOT NULL DEFAULT 1 CHECK (allow_join IN (0, 1)),
 
-  FOREIGN KEY (lecturer_id) REFERENCES staff(staff_number) ON DELETE SET NULL,
-  FOREIGN KEY (organiser)   REFERENCES students(student_number) ON DELETE SET NULL
+  FOREIGN KEY (lecturer_id)     REFERENCES staff(staff_number) ON DELETE SET NULL,
+  FOREIGN KEY (organiser)       REFERENCES students(student_number) ON DELETE SET NULL,
+  FOREIGN KEY (availability_id) REFERENCES lecturer_availability(availability_id) ON DELETE SET NULL
 );
 
 CREATE TABLE consultation_attendees (

--- a/database/seedVitalInfo.sql
+++ b/database/seedVitalInfo.sql
@@ -303,6 +303,10 @@ INSERT OR IGNORE INTO staff_courses (staff_number, course_code) VALUES
 INSERT OR IGNORE INTO students (student_number, name, email, password, degree_code) VALUES
   (1234567, 'Aditya Raghunandan', 'aditya@students.wits.ac.za', 'pass', 'BSCENGINFO');
 
+INSERT OR IGNORE INTO enrollments (student_number, course_code) VALUES
+  (1234567, 'ELEN4010'),
+  (1234567, 'ELEN3009');
+
 -- ─── Admin ────────────────────────────────────────────────────────────────────
 INSERT OR IGNORE INTO admins (admin_id, name, email, password) VALUES
   ('ADMIN001', 'System Admin', 'admin@wits.ac.za', 'admin');

--- a/documentation/ADR's/ADR-010-booking-flow.md
+++ b/documentation/ADR's/ADR-010-booking-flow.md
@@ -64,3 +64,30 @@ A migration script was explicitly not written because the project rebuilds the d
 - The `computeBookableChunks` and `canBookInRange` helpers are pure functions in `src/services/booking-helpers.js` — all overlap and capacity logic belongs there, not in controllers.
 - Cancel and Leave flows are out of scope for this PR. The detail page renders the buttons but routes them to placeholder handlers that return an "not yet implemented" message. These are tracked as follow-up stories.
 - The lecturer dashboard is untouched. All calendar and booking UI is on the student dashboard only.
+
+## Post-implementation fixes
+
+Two issues were identified and resolved after the initial 10 commits:
+
+**Course-detail schedule buttons linked to a placeholder date.**
+The `date=PICK` literal was never replaced during the initial build. The
+course-detail controller now computes `nextDateByDow` — for each recurring
+`day_of_week` in the availability grid, it finds the next real calendar
+occurrence starting from tomorrow, skipping weekends. This ensures Schedule
+buttons always link to a future bookable date rather than a date that may
+have already passed.
+
+**E2E test rows accumulated in the database.**
+The Playwright booking-flow spec had no teardown. Each run left a
+"E2E Test Booking {timestamp}" row in `consultations`. The spec was updated
+to run `purgeE2ERows()` in `beforeAll` and `afterEach`, keying on the
+`consultation_title LIKE 'E2E Test Booking %'` pattern. Three stale rows
+were manually cleared from the development database.
+
+**UI polish.**
+The colour palette in `booking-helpers.js` was extended from 8 to 12 colours
+to support students enrolled in more courses before colour collisions occur.
+Course cards on the student dashboard now have a hover state making them
+visually interactive. Calendar week labels changed from hardcoded
+"This week" / "Next week" to actual date ranges (e.g. "11 May – 15 May") so
+they are unambiguous regardless of the day of the week.

--- a/documentation/ADR's/ADR-010-booking-flow.md
+++ b/documentation/ADR's/ADR-010-booking-flow.md
@@ -1,0 +1,66 @@
+# ADR-010: Consultation Discovery and Booking Flow
+
+**Date:** 2026-05-09
+**Status:** Accepted
+**Issues:** #9, #47, #48, #89, #90, #91
+
+---
+
+## Context
+
+Students need to discover when their lecturers are available, book a consultation slot within those windows, and optionally allow classmates to join the same session. This ADR documents the key decisions made when implementing the booking flow across issues #9, #47, #48, #89, #90, and #91.
+
+---
+
+## Decisions
+
+### 1. Slot moulding rule (continuous window minus bookings)
+
+When a student books a time range inside a lecturer's recurring availability window, that booked range is subtracted from the window. The remaining free time is presented as one or more contiguous "bookable chunks" to the next student.
+
+**Example:** Window 14:00–16:00, booking at 14:00–14:15 → other students see one bookable chunk of 14:15–16:00.
+
+This approach was chosen over a "fixed slot grid" (e.g., always 15-min slots) because it preserves flexibility: students can book any duration up to `max_booking_min` without the app dictating a predetermined grid. A grid would require the lecturer to configure slot sizes upfront and would waste time if no one books a particular slot.
+
+**Implementation:** `computeBookableChunks(window, bookingsOnDay)` in `src/services/booking-helpers.js` performs this computation as a pure function, making it straightforward to unit test without database access.
+
+### 2. Joinable consultation pattern (organiser opt-in)
+
+When a student creates a consultation, they choose whether other students may join (checkbox, default = true). This `allow_join` flag is stored on the consultation row.
+
+- If `allow_join = 1` and the consultation has not yet reached `max_number_of_students`, other enrolled students see a "Join" button on the dashboard calendar and on the booking page.
+- If `allow_join = 0`, the slot is locked to the organiser only and shows as "Booked" to others.
+
+**Why a dedicated column rather than a computed rule:** Alternatives considered included deriving joinability from the consultation status or from whether the organiser explicitly invited attendees. A computed rule would have required either a separate invitations table or an attendee-whitelist mechanism. Storing `allow_join` as a simple integer on the consultation row keeps the query simple (a single `allow_join = 1` filter) and makes the organiser's intent explicit and stable across status transitions.
+
+### 3. Capacity is per-time-instant, not per-window
+
+`max_number_of_students` on a `lecturer_availability` row defines how many students can occupy the window at any single point in time, not the total across the whole window. Two students booking non-overlapping 15-minute slots in the same window each occupy capacity only during their own slot. This is validated by `canBookInRange()` in `booking-helpers.js`, which counts overlapping attendees at booking time rather than counting all bookings in the day.
+
+### 4. Discovery is course-first, not lecturer-first
+
+Students navigate: Dashboard → course card → course detail page → availability grid → booking page. The alternative (student picks a lecturer directly) was rejected because students think in terms of which course they need help with, not which lecturer they want to see. Showing availability grouped by course also makes it natural to colour-code the calendar by course on the dashboard.
+
+### 5. Duration is student-controlled with no overflow enforcement
+
+The booking page offers a duration slider from 15 minutes up to `min(window.max_booking_min, chunk_length)`. Once the student submits a booking, the app validates that `start_time + duration_min` fits within the window but does not cap or warn if the student chooses an optimistic duration. Students must be given the authority to judge how long they need; the app should not second-guess this. The risk that a student underestimates consultation length and runs over into a neighbouring slot is acceptable: the availability window sets an outer boundary, and the lecturer can manage overruns in person.
+
+### 6. Schema additions to `consultations`
+
+Two columns were added (schema rebuilt via `npm run setup`; no migration required):
+
+| Column | Type | Default | Purpose |
+|---|---|---|---|
+| `allow_join` | `INTEGER` | `1` | Organiser opt-in flag for joinability |
+| `availability_id` | `INTEGER` (FK) | `NULL` | Links the consultation back to the recurring window, enabling efficient per-window queries |
+
+A migration script was explicitly not written because the project rebuilds the database from `createSchema.sql` and `seedVitalInfo.sql` on every `npm run setup` call. Any developer pulling this branch must re-run `npm run setup`.
+
+---
+
+## Consequences
+
+- Developers must run `npm run setup` after pulling this branch to pick up the schema changes.
+- The `computeBookableChunks` and `canBookInRange` helpers are pure functions in `src/services/booking-helpers.js` — all overlap and capacity logic belongs there, not in controllers.
+- Cancel and Leave flows are out of scope for this PR. The detail page renders the buttons but routes them to placeholder handlers that return an "not yet implemented" message. These are tracked as follow-up stories.
+- The lecturer dashboard is untouched. All calendar and booking UI is on the student dashboard only.

--- a/src/controllers/consultation-booking-controller.js
+++ b/src/controllers/consultation-booking-controller.js
@@ -1,0 +1,176 @@
+const db = require('../../database/db');
+const { computeBookableChunks, validateBookingRequest, getNextNWeekdays } = require('../services/booking-helpers');
+const { generateConstId } = require('../services/availability-helpers');
+
+const getStudentUser = (req) => req.session && req.session.userId
+  ? { id: req.session.userId, name: req.session.userName, role: req.session.userRole }
+  : { id: 1234567, name: 'Test Student', role: 'student' };
+
+const getToday = () => {
+  const now = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+};
+
+const getCurrentTime = () => {
+  const now = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  return `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+};
+
+const showBookingPage = (req, res) => {
+  const user = getStudentUser(req);
+  const { staffNumber, availabilityId, date } = req.query;
+
+  if (!staffNumber || !availabilityId || !date) {
+    return res.redirect('/student/dashboard?error=Missing+booking+parameters');
+  }
+
+  const enrolled = db.prepare(`
+    SELECT 1 FROM enrollments e
+    JOIN staff_courses sc ON e.course_code = sc.course_code
+    WHERE e.student_number = ? AND sc.staff_number = ?
+  `).get(user.id, staffNumber);
+
+  if (!enrolled) {
+    return res.redirect('/student/dashboard?error=You+are+not+enrolled+in+a+course+taught+by+this+lecturer');
+  }
+
+  const window = db.prepare(
+    'SELECT * FROM lecturer_availability WHERE availability_id = ? AND staff_number = ?'
+  ).get(availabilityId, staffNumber);
+
+  if (!window) {
+    return res.redirect('/student/dashboard?error=Availability+window+not+found');
+  }
+
+  const today = getToday();
+  const todayWeekdays = getNextNWeekdays(new Date(`${today}T12:00:00Z`));
+  const validDates = todayWeekdays.map(d => d.toISOString().split('T')[0]);
+  if (!validDates.includes(date)) {
+    return res.redirect('/student/dashboard?error=Date+is+not+within+the+next+10+weekdays');
+  }
+
+  const bookings = db.prepare(`
+    SELECT c.const_id, c.consultation_time, c.duration_min, c.allow_join,
+           COUNT(ca.student_number) AS attendee_count
+    FROM consultations c
+    LEFT JOIN consultation_attendees ca ON ca.const_id = c.const_id
+    WHERE c.consultation_date = ? AND c.lecturer_id = ? AND c.availability_id = ?
+      AND c.status IN ('Booked', 'Available', 'Ongoing')
+    GROUP BY c.const_id
+  `).all(date, staffNumber, availabilityId);
+
+  const bookableChunks = computeBookableChunks(window, bookings);
+
+  const joinableConsultations = db.prepare(`
+    SELECT c.const_id, c.consultation_title, c.consultation_time, c.duration_min,
+           c.max_number_of_students, c.allow_join, c.venue,
+           COUNT(ca.student_number) AS attendee_count
+    FROM consultations c
+    LEFT JOIN consultation_attendees ca ON ca.const_id = c.const_id
+    WHERE c.consultation_date = ? AND c.lecturer_id = ? AND c.availability_id = ?
+      AND c.status = 'Booked' AND c.allow_join = 1
+      AND NOT EXISTS (
+        SELECT 1 FROM consultation_attendees WHERE const_id = c.const_id AND student_number = ?
+      )
+    GROUP BY c.const_id
+    HAVING COUNT(ca.student_number) < c.max_number_of_students
+  `).all(date, staffNumber, availabilityId, user.id);
+
+  const lecturer = db.prepare('SELECT name FROM staff WHERE staff_number = ?').get(staffNumber);
+
+  const course = db.prepare(`
+    SELECT c.course_code, c.course_name FROM courses c
+    JOIN staff_courses sc ON sc.course_code = c.course_code
+    JOIN enrollments e ON e.course_code = sc.course_code
+    WHERE sc.staff_number = ? AND e.student_number = ?
+    LIMIT 1
+  `).get(staffNumber, user.id);
+
+  return res.render('consultation-new', {
+    user,
+    window,
+    bookableChunks,
+    joinableConsultations,
+    lecturer: lecturer || { name: 'Unknown' },
+    course: course || { course_code: '', course_name: '' },
+    date,
+    staffNumber,
+    availabilityId,
+    error: req.query.error || null,
+    success: null,
+  });
+};
+
+const createBooking = (req, res) => {
+  const user = getStudentUser(req);
+  const { staff_number, availability_id, date, start_time, duration_min, title, description, allow_join } = req.body;
+
+  if (!staff_number || !availability_id || !date || !start_time || !duration_min || !title) {
+    return res.redirect(
+      `/consultations/new?staffNumber=${staff_number}&availabilityId=${availability_id}&date=${date}&error=All+required+fields+must+be+filled`
+    );
+  }
+
+  const window = db.prepare(
+    'SELECT * FROM lecturer_availability WHERE availability_id = ? AND staff_number = ?'
+  ).get(availability_id, staff_number);
+
+  if (!window) {
+    return res.redirect('/student/dashboard?error=Availability+window+not+found');
+  }
+
+  const today = getToday();
+  const currentTimeStr = getCurrentTime();
+
+  const bookings = db.prepare(`
+    SELECT c.const_id, c.consultation_time, c.duration_min, c.allow_join,
+           COUNT(ca.student_number) AS attendee_count
+    FROM consultations c
+    LEFT JOIN consultation_attendees ca ON ca.const_id = c.const_id
+    WHERE c.consultation_date = ? AND c.lecturer_id = ? AND c.availability_id = ?
+      AND c.status IN ('Booked', 'Available', 'Ongoing')
+    GROUP BY c.const_id
+  `).all(date, staff_number, availability_id);
+
+  const validation = validateBookingRequest({
+    date,
+    start_time,
+    duration_min: Number(duration_min),
+    window,
+    bookingsOnDay: bookings,
+    todayStr: today,
+    currentTimeStr,
+  });
+
+  if (!validation.valid) {
+    return res.redirect(
+      `/consultations/new?staffNumber=${staff_number}&availabilityId=${availability_id}&date=${date}&error=${encodeURIComponent(validation.reason)}`
+    );
+  }
+
+  const countRow = db.prepare('SELECT COUNT(*) AS cnt FROM consultations WHERE consultation_date = ?').get(date);
+  const constId = generateConstId(date, countRow.cnt);
+  const allowJoinVal = allow_join === '1' || allow_join === 1 ? 1 : 0;
+
+  db.prepare(`
+    INSERT INTO consultations
+      (const_id, consultation_title, consultation_description, consultation_date, consultation_time,
+       lecturer_id, organiser, availability_id, duration_min, max_number_of_students, venue, status, allow_join)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'Booked', ?)
+  `).run(
+    constId, title, description || null, date, start_time,
+    staff_number, user.id, availability_id,
+    Number(duration_min), window.max_number_of_students, window.venue,
+    allowJoinVal
+  );
+
+  db.prepare(
+    'INSERT INTO consultation_attendees (const_id, student_number) VALUES (?, ?)'
+  ).run(constId, user.id);
+
+  return res.redirect('/student/dashboard?success=Consultation+booked');
+};
+
+module.exports = { showBookingPage, createBooking };

--- a/src/controllers/consultation-detail-controller.js
+++ b/src/controllers/consultation-detail-controller.js
@@ -1,0 +1,100 @@
+const db = require('../../database/db');
+const { validateJoin } = require('../services/consultation-join-service');
+
+const getStudentUser = (req) => req.session && req.session.userId
+  ? { id: req.session.userId, name: req.session.userName, role: req.session.userRole }
+  : { id: 1234567, name: 'Test Student', role: 'student' };
+
+const showConsultationDetail = (req, res) => {
+  const user = getStudentUser(req);
+  const { constId } = req.params;
+
+  const consultation = db.prepare(`
+    SELECT c.*, s.name AS lecturer_name
+    FROM consultations c
+    LEFT JOIN staff s ON s.staff_number = c.lecturer_id
+    WHERE c.const_id = ?
+  `).get(constId);
+
+  if (!consultation) {
+    return res.redirect('/student/dashboard?error=Consultation+not+found');
+  }
+
+  const isEnrolled = db.prepare(`
+    SELECT 1 FROM enrollments e
+    JOIN staff_courses sc ON e.course_code = sc.course_code
+    WHERE e.student_number = ? AND sc.staff_number = ?
+  `).get(user.id, consultation.lecturer_id);
+
+  const attendees = db.prepare(`
+    SELECT ca.student_number, s.name
+    FROM consultation_attendees ca
+    JOIN students s ON s.student_number = ca.student_number
+    WHERE ca.const_id = ?
+  `).all(constId);
+
+  const isAttendee = attendees.some(a => a.student_number === user.id);
+
+  if (!isAttendee && !isEnrolled) {
+    return res.status(403).render('error', { message: 'You do not have access to this consultation.' });
+  }
+
+  const isOrganiser = consultation.organiser === user.id;
+  const spotsRemaining = consultation.max_number_of_students - attendees.length;
+  const canJoin = !isAttendee && !isOrganiser && consultation.allow_join && spotsRemaining > 0;
+
+  const organiserRow = attendees.find(a => a.student_number === consultation.organiser);
+
+  return res.render('consultation-detail', {
+    user,
+    consultation,
+    attendees,
+    isOrganiser,
+    isAttendee,
+    canJoin,
+    spotsRemaining,
+    organiserName: organiserRow ? organiserRow.name : 'Unknown',
+    error: req.query.error || null,
+    success: req.query.success || null,
+  });
+};
+
+const joinConsultation = (req, res) => {
+  const user = getStudentUser(req);
+  const { constId } = req.params;
+
+  const consultation = db.prepare('SELECT * FROM consultations WHERE const_id = ?').get(constId);
+  const attendees = db.prepare(
+    'SELECT student_number FROM consultation_attendees WHERE const_id = ?'
+  ).all(constId);
+
+  const validation = validateJoin(consultation, user.id, attendees);
+  if (!validation.valid) {
+    return res.redirect(`/student/dashboard?error=${encodeURIComponent(validation.reason)}`);
+  }
+
+  const isEnrolled = consultation.lecturer_id
+    ? db.prepare(`
+        SELECT 1 FROM enrollments e
+        JOIN staff_courses sc ON e.course_code = sc.course_code
+        WHERE e.student_number = ? AND sc.staff_number = ?
+      `).get(user.id, consultation.lecturer_id)
+    : null;
+
+  if (!isEnrolled) {
+    return res.redirect('/student/dashboard?error=You+are+not+enrolled+in+a+course+taught+by+this+lecturer');
+  }
+
+  db.prepare('INSERT INTO consultation_attendees (const_id, student_number) VALUES (?, ?)').run(constId, user.id);
+  return res.redirect('/student/dashboard?success=Successfully+joined+consultation');
+};
+
+const cancelConsultationTodo = (req, res) => {
+  return res.redirect(`/consultations/${req.params.constId}?error=Cancel+not+yet+implemented`);
+};
+
+const leaveConsultationTodo = (req, res) => {
+  return res.redirect(`/consultations/${req.params.constId}?error=Leave+not+yet+implemented`);
+};
+
+module.exports = { showConsultationDetail, joinConsultation, cancelConsultationTodo, leaveConsultationTodo };

--- a/src/controllers/course-detail-controller.js
+++ b/src/controllers/course-detail-controller.js
@@ -1,0 +1,85 @@
+const db = require('../../database/db');
+
+const DAYS_ORDER = { Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5 };
+
+const showCourseDetail = (req, res) => {
+  const studentNumber = req.session && req.session.userId ? req.session.userId : 1234567;
+  const { courseCode } = req.params;
+
+  const enrollment = db.prepare(
+    'SELECT 1 FROM enrollments WHERE student_number = ? AND course_code = ?'
+  ).get(studentNumber, courseCode);
+
+  if (!enrollment) {
+    return res.redirect(`/student/dashboard?error=Not+enrolled+in+that+course`);
+  }
+
+  const course = db.prepare('SELECT * FROM courses WHERE course_code = ?').get(courseCode);
+  if (!course) {
+    return res.redirect('/student/dashboard?error=Course+not+found');
+  }
+
+  const rows = db.prepare(`
+    SELECT
+      s.staff_number, s.name AS lecturer_name,
+      la.availability_id, la.day_of_week, la.start_time, la.end_time,
+      la.max_booking_min, la.max_number_of_students, la.venue
+    FROM staff_courses sc
+    JOIN staff s ON sc.staff_number = s.staff_number
+    LEFT JOIN lecturer_availability la ON s.staff_number = la.staff_number
+    WHERE sc.course_code = ?
+    ORDER BY s.name,
+      CASE la.day_of_week
+        WHEN 'Mon' THEN 1 WHEN 'Tue' THEN 2 WHEN 'Wed' THEN 3
+        WHEN 'Thu' THEN 4 WHEN 'Fri' THEN 5 END,
+      la.start_time
+  `).all(courseCode);
+
+  const lecturerMap = {};
+  for (const row of rows) {
+    if (!lecturerMap[row.staff_number]) {
+      lecturerMap[row.staff_number] = { staff_number: row.staff_number, lecturer_name: row.lecturer_name, slots: [] };
+    }
+    if (row.availability_id) {
+      lecturerMap[row.staff_number].slots.push({
+        availability_id: row.availability_id,
+        day_of_week: row.day_of_week,
+        start_time: row.start_time,
+        end_time: row.end_time,
+        max_booking_min: row.max_booking_min,
+        max_number_of_students: row.max_number_of_students,
+        venue: row.venue,
+      });
+    }
+  }
+  const lecturers = Object.values(lecturerMap);
+
+  const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+  const byDay = {};
+  for (const day of WEEKDAYS) {
+    byDay[day] = [];
+    for (const lec of lecturers) {
+      for (const slot of lec.slots) {
+        if (slot.day_of_week === day) {
+          byDay[day].push({ ...slot, staff_number: lec.staff_number, lecturer_name: lec.lecturer_name });
+        }
+      }
+    }
+  }
+
+  const user = req.session && req.session.userId
+    ? { id: req.session.userId, name: req.session.userName, role: req.session.userRole }
+    : { id: 1234567, name: 'Test Student', role: 'student' };
+
+  return res.render('course-detail', {
+    user,
+    course,
+    lecturers,
+    byDay,
+    WEEKDAYS,
+    courseCode,
+    error: req.query.error || null,
+  });
+};
+
+module.exports = { showCourseDetail };

--- a/src/controllers/course-detail-controller.js
+++ b/src/controllers/course-detail-controller.js
@@ -1,6 +1,7 @@
 const db = require('../../database/db');
+const { getNextNWeekdays } = require('../services/booking-helpers');
 
-const DAYS_ORDER = { Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5 };
+const DOW_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 const showCourseDetail = (req, res) => {
   const studentNumber = req.session && req.session.userId ? req.session.userId : 1234567;
@@ -71,12 +72,29 @@ const showCourseDetail = (req, res) => {
     ? { id: req.session.userId, name: req.session.userName, role: req.session.userRole }
     : { id: 1234567, name: 'Test Student', role: 'student' };
 
+  // Compute the next future occurrence of each weekday (starting from tomorrow
+  // so we never point at a slot that may have already passed today).
+  const now = new Date();
+  const pad = n => String(n).padStart(2, '0');
+  const today = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+  const tomorrow = new Date(`${today}T12:00:00Z`);
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  const upcomingDays = getNextNWeekdays(tomorrow, 10);
+  const nextDateByDow = {};
+  for (const d of upcomingDays) {
+    const dow = DOW_NAMES[d.getUTCDay()];
+    if (!nextDateByDow[dow]) {
+      nextDateByDow[dow] = d.toISOString().split('T')[0];
+    }
+  }
+
   return res.render('course-detail', {
     user,
     course,
     lecturers,
     byDay,
     WEEKDAYS,
+    nextDateByDow,
     courseCode,
     error: req.query.error || null,
   });

--- a/src/controllers/student-dashboard-controller.js
+++ b/src/controllers/student-dashboard-controller.js
@@ -1,125 +1,196 @@
 const db = require('../../database/db');
+const { getNextNWeekdays, colourForCourse } = require('../services/booking-helpers');
+
+const DOW_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 const showStudentDashboard = (req, res) => {
-    // Temporary: hardcode student until auth landscape is set up. Should be able to get from session once login is implemented.
-    const user = req.session && req.session.userId ? {
-        id: req.session.userId,
-        name: req.session.userName,
-        role: req.session.userRole,
-    } : {
-        id: 1234567, // Default student number for testing
-        name: 'Test Student',
-        role: 'student',
-    };
+  const user = req.session && req.session.userId ? {
+    id: req.session.userId,
+    name: req.session.userName,
+    role: req.session.userRole,
+  } : {
+    id: 1234567,
+    name: 'Test Student',
+    role: 'student',
+  };
 
-    try {
+  try {
+    const showWelcome = req.session.showWelcome || false;
+    req.session.showWelcome = false;
 
-        const showWelcome       = req.session.showWelcome || false;
-        req.session.showWelcome = false;
-        const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+    const now = new Date();
+    const pad = n => String(n).padStart(2, '0');
+    const today = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+    const currentTimeStr = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
 
-        const degreeRow = db.prepare(`
-            SELECT d.degree_name
-            FROM students s
-            JOIN degrees d ON s.degree_code = d.degree_code
-            WHERE s.student_number = ?
-        `).get(user.id);
-        const degreeName = degreeRow ? degreeRow.degree_name : null;
+    const degreeRow = db.prepare(`
+      SELECT d.degree_name
+      FROM students s
+      JOIN degrees d ON s.degree_code = d.degree_code
+      WHERE s.student_number = ?
+    `).get(user.id);
+    const degreeName = degreeRow ? degreeRow.degree_name : null;
 
-        // student is in attendees JSON array AND date is today/future
-        // json_each expands the attendees array so we can filter by it.
-        // The CAST is because attendees are stored as numbers in JSON but
-        // SQLite json_each returns them as text values by default.
-        const enrolledCourses = db.prepare(`
-            SELECT c.course_code, c.course_name, c.year_level, c.dept_code
-            FROM enrollments e
-            JOIN courses c ON e.course_code = c.course_code
-            WHERE e.student_number = ?
-            ORDER BY c.year_level, c.course_code
-        `).all(user.id);
+    const enrolledCourses = db.prepare(`
+      SELECT c.course_code, c.course_name, c.year_level, c.dept_code
+      FROM enrollments e
+      JOIN courses c ON e.course_code = c.course_code
+      WHERE e.student_number = ?
+      ORDER BY c.year_level, c.course_code
+    `).all(user.id);
 
-        const upcomingRows = db.prepare(`
-          SELECT
-            c.const_id,
-            c.consultation_title,
-            c.consultation_date,
-            c.consultation_time,
-            c.duration_min,
-            c.max_number_of_students,
-            c.venue,
-            c.status,
-            s.name AS lecturer_name,
-            COUNT(ca.student_number) AS attendeeCount
-          FROM consultations c
-          LEFT JOIN staff s ON s.staff_number = c.lecturer_id
-          LEFT JOIN consultation_attendees ca ON ca.const_id = c.const_id
-          WHERE c.consultation_date >= ?
-            AND c.status IN ('Available', 'Booked', 'Ongoing')
-            AND EXISTS (
-              SELECT 1 FROM consultation_attendees
-              WHERE const_id = c.const_id AND student_number = ?
-            )
-          GROUP BY c.const_id
-          ORDER BY c.consultation_date ASC, c.consultation_time ASC
-        `).all(today, user.id);
+    const upcomingRows = db.prepare(`
+      SELECT
+        c.const_id,
+        c.consultation_title,
+        c.consultation_date,
+        c.consultation_time,
+        c.duration_min,
+        c.max_number_of_students,
+        c.venue,
+        c.status,
+        c.allow_join,
+        s.name AS lecturer_name,
+        COUNT(ca.student_number) AS attendeeCount
+      FROM consultations c
+      LEFT JOIN staff s ON s.staff_number = c.lecturer_id
+      LEFT JOIN consultation_attendees ca ON ca.const_id = c.const_id
+      WHERE c.consultation_date >= ?
+        AND c.status IN ('Available', 'Booked', 'Ongoing')
+        AND EXISTS (
+          SELECT 1 FROM consultation_attendees
+          WHERE const_id = c.const_id AND student_number = ?
+        )
+      GROUP BY c.const_id
+      ORDER BY c.consultation_date ASC, c.consultation_time ASC
+    `).all(today, user.id);
 
-        const pastRows = db.prepare(`
-        SELECT
-          c.const_id,
-          c.consultation_title,
-          c.consultation_date,
-          c.consultation_time,
-          c.max_number_of_students,
-          c.status,
-          s.name AS lecturer_name,
-          COUNT(ca.student_number) AS attendeeCount
-        FROM consultations c
-        LEFT JOIN staff s ON s.staff_number = c.lecturer_id
-        LEFT JOIN consultation_attendees ca ON ca.const_id = c.const_id
-        WHERE c.consultation_date < ?
-          AND EXISTS (
-            SELECT 1 FROM consultation_attendees
-            WHERE const_id = c.const_id AND student_number = ?
-          )
-        GROUP BY c.const_id
-        ORDER BY c.consultation_date DESC, c.consultation_time DESC
-      `).all(today, user.id);
+    const pastRows = db.prepare(`
+      SELECT
+        c.const_id,
+        c.consultation_title,
+        c.consultation_date,
+        c.consultation_time,
+        c.max_number_of_students,
+        c.status,
+        s.name AS lecturer_name,
+        COUNT(ca.student_number) AS attendeeCount
+      FROM consultations c
+      LEFT JOIN staff s ON s.staff_number = c.lecturer_id
+      LEFT JOIN consultation_attendees ca ON ca.const_id = c.const_id
+      WHERE c.consultation_date < ?
+        AND EXISTS (
+          SELECT 1 FROM consultation_attendees
+          WHERE const_id = c.const_id AND student_number = ?
+        )
+      GROUP BY c.const_id
+      ORDER BY c.consultation_date DESC, c.consultation_time DESC
+    `).all(today, user.id);
 
-        // const parseRow = (row) => {
-        //     let list = [];
-        //     try { list = JSON.parse(row.attendees || '[]'); } catch {  }
-        //     return { ...row, attendeeCount: list.length };
-        // };
+    const calendarDayObjs = getNextNWeekdays(new Date(`${today}T12:00:00Z`));
+    const calendarDays = calendarDayObjs.map(d => d.toISOString().split('T')[0]);
+    const lastDay = calendarDays[calendarDays.length - 1];
 
-        // const upcomingConsultations = upcomingRows.map(parseRow);
-        // const pastConsultations = pastRows.map(parseRow);
+    const availabilityRows = db.prepare(`
+      SELECT DISTINCT
+        s.staff_number, s.name AS lecturer_name,
+        sc.course_code,
+        la.availability_id, la.day_of_week, la.start_time, la.end_time,
+        la.max_booking_min, la.max_number_of_students, la.venue
+      FROM enrollments e
+      JOIN staff_courses sc ON e.course_code = sc.course_code
+      JOIN staff s ON sc.staff_number = s.staff_number
+      JOIN lecturer_availability la ON s.staff_number = la.staff_number
+      WHERE e.student_number = ?
+    `).all(user.id);
 
-        const upcomingConsultations = upcomingRows;
-        const pastConsultations = pastRows;
-        const welcomeMessage = `Welcome back, ${user.name}! Check your upcoming consultations below.`;
+    const colourMap = {};
+    for (const c of enrolledCourses) {
+      colourMap[c.course_code] = colourForCourse(c.course_code);
+    }
 
-        return res.render('student-dashboard', {
-            user,
-            degreeName,
-            enrolledCourses,
-            upcomingConsultations,
-            pastConsultations,
-            success: showWelcome ? welcomeMessage : (req.query.success === 'true' ? 'Courses updated successfully.' : null),
-      error: null,
+    const availabilityByDay = {};
+    for (const dateStr of calendarDays) {
+      const d = new Date(`${dateStr}T12:00:00Z`);
+      const dow = DOW_NAMES[d.getUTCDay()];
+      availabilityByDay[dateStr] = availabilityRows
+        .filter(a => a.day_of_week === dow)
+        .map(a => ({ ...a, course_colour: colourMap[a.course_code] || '#6c757d' }));
+    }
+
+    const joinableRows = db.prepare(`
+      SELECT
+        c.const_id, c.consultation_title, c.consultation_date, c.consultation_time,
+        c.duration_min, c.max_number_of_students, c.venue, c.status, c.allow_join,
+        c.lecturer_id, s.name AS lecturer_name,
+        COUNT(ca.student_number) AS attendeeCount
+      FROM consultations c
+      JOIN staff s ON s.staff_number = c.lecturer_id
+      LEFT JOIN consultation_attendees ca ON ca.const_id = c.const_id
+      WHERE c.consultation_date >= ? AND c.consultation_date <= ?
+        AND c.status = 'Booked'
+        AND c.allow_join = 1
+        AND c.lecturer_id IN (
+          SELECT DISTINCT sc.staff_number FROM staff_courses sc
+          JOIN enrollments e ON e.course_code = sc.course_code
+          WHERE e.student_number = ?
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM consultation_attendees
+          WHERE const_id = c.const_id AND student_number = ?
+        )
+      GROUP BY c.const_id
+      HAVING COUNT(ca.student_number) < c.max_number_of_students
+    `).all(today, lastDay, user.id, user.id);
+
+    const bookedConsultationsByDay = {};
+    for (const dateStr of calendarDays) {
+      bookedConsultationsByDay[dateStr] = joinableRows.filter(r => r.consultation_date === dateStr);
+    }
+
+    let success = null;
+    if (showWelcome) {
+      success = `Welcome back, ${user.name}! Check your upcoming consultations below.`;
+    } else if (req.query.success === 'true') {
+      success = 'Courses updated successfully.';
+    } else if (req.query.success) {
+      success = req.query.success;
+    }
+
+    return res.render('student-dashboard', {
+      user,
+      degreeName,
+      enrolledCourses,
+      upcomingConsultations: upcomingRows,
+      pastConsultations: pastRows,
+      calendarDays,
+      availabilityByDay,
+      bookedConsultationsByDay,
+      colourMap,
+      today,
+      currentTimeStr,
+      success,
+      error: req.query.error || null,
     });
 
-    } catch (err) {
-        console.error('Student dashboard error:', err);
-        return res.render('student-dashboard', {
-            user,
-            degreeName: null,
-            enrolledCourses: [],
-            upcomingConsultations: [],
-            pastConsultations: [],
-            error: 'Could not load dashboard data. Please try again.',
-            success: null,
-        });
-    }
+  } catch (err) {
+    console.error('Student dashboard error:', err);
+    return res.render('student-dashboard', {
+      user,
+      degreeName: null,
+      enrolledCourses: [],
+      upcomingConsultations: [],
+      pastConsultations: [],
+      calendarDays: [],
+      availabilityByDay: {},
+      bookedConsultationsByDay: {},
+      colourMap: {},
+      today: new Date().toISOString().split('T')[0],
+      currentTimeStr: '00:00',
+      error: 'Could not load dashboard data. Please try again.',
+      success: null,
+    });
+  }
 };
 
 module.exports = { showStudentDashboard };

--- a/src/routes/consultation-routes.js
+++ b/src/routes/consultation-routes.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const { showBookingPage, createBooking } = require('../controllers/consultation-booking-controller');
+const {
+  showConsultationDetail,
+  joinConsultation,
+  cancelConsultationTodo,
+  leaveConsultationTodo,
+} = require('../controllers/consultation-detail-controller');
+
+const router = express.Router();
+
+router.get('/consultations/new', showBookingPage);
+router.post('/consultations/new', createBooking);
+router.get('/consultations/:constId', showConsultationDetail);
+router.post('/consultations/:constId/join', joinConsultation);
+router.post('/consultations/:constId/cancel', cancelConsultationTodo);
+router.post('/consultations/:constId/leave', leaveConsultationTodo);
+
+module.exports = router;

--- a/src/routes/course-routes.js
+++ b/src/routes/course-routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { showCourseDetail } = require('../controllers/course-detail-controller');
+
+const router = express.Router();
+
+router.get('/courses/:courseCode', showCourseDetail);
+
+module.exports = router;

--- a/src/services/booking-helpers.js
+++ b/src/services/booking-helpers.js
@@ -1,0 +1,115 @@
+const toMin = (timeStr) => {
+  const [h, m] = timeStr.split(':').map(Number);
+  return h * 60 + m;
+};
+
+const fromMin = (totalMin) => {
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+};
+
+const PALETTE = [
+  '#0d6efd',
+  '#198754',
+  '#dc3545',
+  '#fd7e14',
+  '#6f42c1',
+  '#20c997',
+  '#0dcaf0',
+  '#d63384',
+];
+
+const computeBookableChunks = (window, bookingsOnDay) => {
+  let chunks = [{ start: toMin(window.start_time), end: toMin(window.end_time) }];
+
+  for (const booking of bookingsOnDay) {
+    const bStart = toMin(booking.consultation_time);
+    const bEnd = bStart + Number(booking.duration_min);
+    const next = [];
+    for (const chunk of chunks) {
+      if (bEnd <= chunk.start || bStart >= chunk.end) {
+        next.push(chunk);
+      } else {
+        if (bStart > chunk.start) next.push({ start: chunk.start, end: bStart });
+        if (bEnd < chunk.end) next.push({ start: bEnd, end: chunk.end });
+      }
+    }
+    chunks = next;
+  }
+
+  return chunks.map(c => ({
+    start_time: fromMin(c.start),
+    end_time: fromMin(c.end),
+    max_students: window.max_number_of_students,
+  }));
+};
+
+const canBookInRange = (window, bookingsOnDay, startTime, endTime) => {
+  const rStart = toMin(startTime);
+  const rEnd = toMin(endTime);
+
+  const overlapping = bookingsOnDay.filter(b => {
+    const bStart = toMin(b.consultation_time);
+    const bEnd = bStart + Number(b.duration_min);
+    return rStart < bEnd && rEnd > bStart;
+  });
+
+  if (overlapping.some(b => !b.allow_join)) return false;
+
+  const totalAttendees = overlapping.reduce((sum, b) => sum + (b.attendee_count || 1), 0);
+  return totalAttendees < window.max_number_of_students;
+};
+
+const colourForCourse = (courseCode) => {
+  let hash = 0;
+  for (let i = 0; i < courseCode.length; i++) {
+    hash = (hash * 31 + courseCode.charCodeAt(i)) | 0;
+  }
+  return PALETTE[Math.abs(hash) % PALETTE.length];
+};
+
+const getNextNWeekdays = (startDate, n = 10) => {
+  const days = [];
+  const d = new Date(startDate);
+  d.setUTCHours(12, 0, 0, 0);
+  while (days.length < n) {
+    const dow = d.getUTCDay();
+    if (dow !== 0 && dow !== 6) {
+      days.push(new Date(d));
+    }
+    d.setUTCDate(d.getUTCDate() + 1);
+  }
+  return days;
+};
+
+const validateBookingRequest = ({ date, start_time, duration_min, window, bookingsOnDay, todayStr, currentTimeStr }) => {
+  const weekdays = getNextNWeekdays(new Date(`${todayStr}T12:00:00Z`));
+  const dateStrs = weekdays.map(d => d.toISOString().split('T')[0]);
+  if (!dateStrs.includes(date)) {
+    return { valid: false, reason: 'Date is not within the next 10 weekdays.' };
+  }
+
+  const bookingStart = toMin(start_time);
+  const bookingEnd = bookingStart + Number(duration_min);
+  const windowStart = toMin(window.start_time);
+  const windowEnd = toMin(window.end_time);
+
+  if (bookingStart < windowStart || bookingEnd > windowEnd) {
+    return { valid: false, reason: 'Booking time does not fit within the availability window.' };
+  }
+
+  if (date === todayStr && currentTimeStr) {
+    if (bookingStart <= toMin(currentTimeStr)) {
+      return { valid: false, reason: 'Booking start time must be in the future.' };
+    }
+  }
+
+  if (!canBookInRange(window, bookingsOnDay, start_time, fromMin(bookingEnd))) {
+    return { valid: false, reason: 'Time slot is unavailable due to existing bookings or full capacity.' };
+  }
+
+  return { valid: true };
+};
+
+module.exports = { computeBookableChunks, canBookInRange, colourForCourse, getNextNWeekdays, validateBookingRequest };

--- a/src/services/booking-helpers.js
+++ b/src/services/booking-helpers.js
@@ -18,6 +18,10 @@ const PALETTE = [
   '#20c997',
   '#0dcaf0',
   '#d63384',
+  '#ff5722',
+  '#607d8b',
+  '#795548',
+  '#6610f2',
 ];
 
 const computeBookableChunks = (window, bookingsOnDay) => {

--- a/src/services/consultation-join-service.js
+++ b/src/services/consultation-join-service.js
@@ -1,0 +1,20 @@
+const validateJoin = (consultation, studentNumber, attendees) => {
+  if (!consultation) {
+    return { valid: false, reason: 'Consultation not found.' };
+  }
+  if (consultation.status !== 'Booked') {
+    return { valid: false, reason: 'Only consultations with Booked status can be joined.' };
+  }
+  if (!consultation.allow_join) {
+    return { valid: false, reason: 'This consultation does not allow joining.' };
+  }
+  if (attendees.length >= consultation.max_number_of_students) {
+    return { valid: false, reason: 'This consultation is at full capacity.' };
+  }
+  if (attendees.some(a => a.student_number === studentNumber)) {
+    return { valid: false, reason: 'You are already attending this consultation.' };
+  }
+  return { valid: true };
+};
+
+module.exports = { validateJoin };

--- a/src/views/consultation-detail.html
+++ b/src/views/consultation-detail.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= consultation.consultation_title %></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { background: #f5f7fb; }
+    .topbar { border-bottom: 1px solid #dde2e6; background: #fff; }
+    .brand { font-size: 1.5rem; font-weight: 700; }
+    .card { border-radius: 16px; box-shadow: 0 2px 10px rgba(0,0,0,.06); border: none; }
+  </style>
+</head>
+<body>
+  <header class="topbar p-3 d-flex justify-content-between align-items-center">
+    <div class="brand">Knock Knock, <%= user.name %></div>
+    <div class="d-flex align-items-center gap-3">
+      <a href="/student/dashboard" class="btn btn-outline-primary btn-sm">Dashboard</a>
+    </div>
+  </header>
+
+  <main class="container p-4" style="max-width:700px;">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/student/dashboard">Dashboard</a></li>
+        <li class="breadcrumb-item active"><%= consultation.consultation_title %></li>
+      </ol>
+    </nav>
+
+    <% if (typeof error !== 'undefined' && error) { %>
+      <div class="alert alert-warning"><%= error %></div>
+    <% } %>
+    <% if (typeof success !== 'undefined' && success) { %>
+      <div class="alert alert-success"><%= success %></div>
+    <% } %>
+
+    <div class="card p-4 mb-4">
+      <div class="d-flex justify-content-between align-items-start mb-3">
+        <h3 class="mb-0"><%= consultation.consultation_title %></h3>
+        <span class="badge <%=
+          consultation.status === 'Booked'  ? 'bg-primary' :
+          consultation.status === 'Ongoing' ? 'bg-success' : 'bg-secondary'
+        %>"><%= consultation.status %></span>
+      </div>
+
+      <% if (consultation.consultation_description) { %>
+        <p class="text-muted"><%= consultation.consultation_description %></p>
+      <% } %>
+
+      <div class="row g-3 mb-3">
+        <div class="col-sm-6">
+          <div class="text-muted small">Lecturer</div>
+          <div class="fw-semibold"><%= consultation.lecturer_name || 'Unknown' %></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="text-muted small">Date &amp; Time</div>
+          <div class="fw-semibold"><%= consultation.consultation_date %> at <%= consultation.consultation_time %></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="text-muted small">Duration</div>
+          <div class="fw-semibold"><%= consultation.duration_min %> minutes</div>
+        </div>
+        <div class="col-sm-6">
+          <div class="text-muted small">Venue</div>
+          <div class="fw-semibold"><%= consultation.venue %></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="text-muted small">Capacity</div>
+          <div class="fw-semibold"><%= attendees.length %>/<%= consultation.max_number_of_students %> &middot; <span class="text-<%= spotsRemaining > 0 ? 'success' : 'danger' %>"><%= spotsRemaining %> spot<%= spotsRemaining !== 1 ? 's' : '' %> remaining</span></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="text-muted small">Open to join</div>
+          <div class="fw-semibold"><%= consultation.allow_join ? 'Yes' : 'No' %></div>
+        </div>
+        <div class="col-sm-6">
+          <div class="text-muted small">Organiser</div>
+          <div class="fw-semibold"><%= organiserName %></div>
+        </div>
+      </div>
+
+      <div class="d-flex gap-2 flex-wrap">
+        <% if (isOrganiser) { %>
+          <form method="POST" action="/consultations/<%= consultation.const_id %>/cancel">
+            <button type="submit" class="btn btn-danger" onclick="return confirm('Cancel this consultation?')">Cancel Consultation</button>
+          </form>
+        <% } else if (isAttendee) { %>
+          <form method="POST" action="/consultations/<%= consultation.const_id %>/leave">
+            <button type="submit" class="btn btn-outline-danger">Leave Consultation</button>
+          </form>
+        <% } else if (canJoin) { %>
+          <form method="POST" action="/consultations/<%= consultation.const_id %>/join">
+            <button type="submit" class="btn btn-warning">Join Consultation</button>
+          </form>
+        <% } %>
+      </div>
+    </div>
+
+    <div class="card p-4">
+      <h5>Attendees (<%= attendees.length %>)</h5>
+      <% if (attendees.length === 0) { %>
+        <p class="text-muted mb-0">No attendees yet.</p>
+      <% } else { %>
+        <ul class="list-group list-group-flush">
+          <% attendees.forEach(a => { %>
+            <li class="list-group-item px-0">
+              <%= a.name %>
+              <% if (a.student_number === consultation.organiser) { %>
+                <span class="badge bg-primary ms-1">Organiser</span>
+              <% } %>
+            </li>
+          <% }) %>
+        </ul>
+      <% } %>
+    </div>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/views/consultation-new.html
+++ b/src/views/consultation-new.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Book a Consultation</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { background: #f5f7fb; }
+    .topbar { border-bottom: 1px solid #dde2e6; background: #fff; }
+    .brand { font-size: 1.5rem; font-weight: 700; }
+    .card { border-radius: 16px; box-shadow: 0 2px 10px rgba(0,0,0,.06); border: none; }
+    .chunk-card { border-left: 4px solid #0d6efd; background: #f0f5ff; border-radius: 8px; padding: 10px 14px; margin-bottom: 8px; cursor: pointer; }
+    .chunk-card.selected { background: #dbeafe; border-left-color: #0847a6; }
+    .chunk-card input[type=radio] { margin-right: 8px; }
+    .joinable-card { border-left: 4px solid #ffc107; background: #fffbea; border-radius: 8px; padding: 10px 14px; margin-bottom: 8px; }
+  </style>
+</head>
+<body>
+  <header class="topbar p-3 d-flex justify-content-between align-items-center">
+    <div class="brand">Knock Knock, <%= user.name %></div>
+    <div class="d-flex align-items-center gap-3">
+      <a href="/student/dashboard" class="btn btn-outline-primary btn-sm">Dashboard</a>
+    </div>
+  </header>
+
+  <main class="container p-4" style="max-width:680px;">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/student/dashboard">Dashboard</a></li>
+        <% if (course && course.course_code) { %>
+          <li class="breadcrumb-item"><a href="/courses/<%= course.course_code %>"><%= course.course_code %></a></li>
+        <% } %>
+        <li class="breadcrumb-item active">Book Consultation</li>
+      </ol>
+    </nav>
+
+    <h3>Book a Consultation</h3>
+    <p class="text-muted">
+      <strong><%= lecturer.name %></strong> &middot; <%= date %> &middot;
+      Window: <%= window.start_time %>–<%= window.end_time %> &middot; <%= window.venue %>
+    </p>
+
+    <% if (typeof error !== 'undefined' && error) { %>
+      <div class="alert alert-danger"><%= error %></div>
+    <% } %>
+
+    <% if (bookableChunks.length === 0 && joinableConsultations.length === 0) { %>
+      <div class="alert alert-warning">No bookable time remains in this window for this date.</div>
+    <% } else { %>
+
+    <% if (joinableConsultations.length > 0) { %>
+    <div class="card p-4 mb-4">
+      <h5>Joinable Consultations</h5>
+      <p class="text-muted small">These consultations are open for you to join.</p>
+      <% joinableConsultations.forEach(con => { %>
+        <div class="joinable-card">
+          <div class="fw-semibold"><%= con.consultation_title %></div>
+          <div class="text-muted small"><%= con.consultation_time %> &middot; <%= con.duration_min %> min &middot; <%= con.venue %></div>
+          <div class="text-muted small"><%= con.attendee_count %>/<%= con.max_number_of_students %> joined</div>
+          <form method="POST" action="/consultations/<%= con.const_id %>/join" class="mt-2">
+            <button type="submit" class="btn btn-warning btn-sm">Join this consultation</button>
+          </form>
+        </div>
+      <% }) %>
+    </div>
+    <% } %>
+
+    <% if (bookableChunks.length > 0) { %>
+    <div class="card p-4">
+      <h5>Create a New Consultation</h5>
+      <form method="POST" action="/consultations/new" id="booking-form">
+        <input type="hidden" name="staff_number" value="<%= staffNumber %>">
+        <input type="hidden" name="availability_id" value="<%= availabilityId %>">
+        <input type="hidden" name="date" value="<%= date %>">
+
+        <div class="mb-3">
+          <label class="form-label fw-semibold">Select a time chunk</label>
+          <% bookableChunks.forEach((chunk, i) => { %>
+            <label class="chunk-card d-block" id="chunk-label-<%= i %>">
+              <input type="radio" name="start_time" value="<%= chunk.start_time %>" required
+                     data-chunk-start="<%= chunk.start_time %>" data-chunk-end="<%= chunk.end_time %>"
+                     onchange="onChunkSelect(this, '<%= chunk.start_time %>', '<%= chunk.end_time %>', <%= window.max_booking_min %>)">
+              <span class="fw-semibold"><%= chunk.start_time %> – <%= chunk.end_time %></span>
+              <span class="text-muted small ms-2">
+                (<%= (function(){
+                  const [sh, sm] = chunk.start_time.split(':').map(Number);
+                  const [eh, em] = chunk.end_time.split(':').map(Number);
+                  return (eh*60+em) - (sh*60+sm);
+                }()) %> min available)
+              </span>
+            </label>
+          <% }) %>
+        </div>
+
+        <div class="mb-3">
+          <label for="duration-slider" class="form-label fw-semibold">
+            Duration: <span id="duration-display">15</span> minutes
+          </label>
+          <input type="range" class="form-range" id="duration-slider" name="duration_min"
+                 min="15" max="<%= window.max_booking_min %>" step="15" value="15"
+                 oninput="updateDuration(this.value)">
+          <div class="text-muted small mt-1">End time: <strong id="end-time-preview">—</strong></div>
+        </div>
+
+        <div class="mb-3">
+          <label for="title" class="form-label fw-semibold">Title <span class="text-danger">*</span></label>
+          <input type="text" class="form-control" id="title" name="title"
+                 minlength="5" maxlength="100" required placeholder="e.g. Assignment 2 help">
+        </div>
+
+        <div class="mb-3">
+          <label for="description" class="form-label fw-semibold">Description (optional)</label>
+          <textarea class="form-control" id="description" name="description"
+                    rows="3" maxlength="500" placeholder="What would you like to discuss?"></textarea>
+        </div>
+
+        <div class="mb-4">
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="allow_join" name="allow_join" value="1" checked>
+            <label class="form-check-label" for="allow_join">
+              Allow other students to join this consultation
+            </label>
+          </div>
+        </div>
+
+        <button type="submit" class="btn btn-primary w-100">Book Consultation</button>
+      </form>
+    </div>
+    <% } %>
+
+    <% } %>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    let selectedChunkStart = null;
+    let selectedChunkEnd = null;
+
+    function toMin(t) {
+      const [h, m] = t.split(':').map(Number);
+      return h * 60 + m;
+    }
+
+    function fromMin(m) {
+      return String(Math.floor(m / 60)).padStart(2, '0') + ':' + String(m % 60).padStart(2, '0');
+    }
+
+    function onChunkSelect(radio, chunkStart, chunkEnd, maxBookingMin) {
+      selectedChunkStart = chunkStart;
+      selectedChunkEnd = chunkEnd;
+
+      const chunkLen = toMin(chunkEnd) - toMin(chunkStart);
+      const maxDur = Math.min(maxBookingMin, chunkLen);
+
+      const slider = document.getElementById('duration-slider');
+      slider.max = maxDur;
+      if (parseInt(slider.value) > maxDur) slider.value = maxDur;
+      updateDuration(slider.value);
+
+      document.querySelectorAll('.chunk-card').forEach(el => el.classList.remove('selected'));
+      radio.closest('.chunk-card').classList.add('selected');
+    }
+
+    function updateDuration(val) {
+      document.getElementById('duration-display').textContent = val;
+      if (selectedChunkStart) {
+        const endMin = toMin(selectedChunkStart) + parseInt(val);
+        document.getElementById('end-time-preview').textContent = fromMin(endMin);
+      }
+    }
+
+    updateDuration(document.getElementById('duration-slider').value);
+  </script>
+</body>
+</html>

--- a/src/views/course-detail.html
+++ b/src/views/course-detail.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= courseCode %> — Course Detail</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { background: #f5f7fb; }
+    .topbar { border-bottom: 1px solid #dde2e6; background: #fff; }
+    .brand { font-size: 1.5rem; font-weight: 700; }
+    .card { border-radius: 16px; box-shadow: 0 2px 10px rgba(0,0,0,.06); border: none; }
+    .day-col { min-width: 140px; }
+    .slot-card {
+      border-left: 4px solid #0d6efd;
+      background: #f0f5ff;
+      border-radius: 8px;
+      padding: 8px 10px;
+      margin-bottom: 6px;
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+  <header class="topbar p-3 d-flex justify-content-between align-items-center">
+    <div class="brand">Knock Knock, <%= user.name %></div>
+    <div class="d-flex align-items-center gap-3">
+      <a href="/student/dashboard" class="btn btn-outline-primary btn-sm">Dashboard</a>
+      <a href="/" class="btn btn-outline-secondary btn-sm">Home</a>
+    </div>
+  </header>
+
+  <main class="container p-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/student/dashboard">Dashboard</a></li>
+        <li class="breadcrumb-item active"><%= courseCode %></li>
+      </ol>
+    </nav>
+
+    <h2><%= courseCode %> — <%= course.course_name %></h2>
+    <p class="text-muted">Year <%= course.year_level %> &middot; <%= course.dept_code %></p>
+
+    <% if (typeof error !== 'undefined' && error) { %>
+      <div class="alert alert-danger"><%= error %></div>
+    <% } %>
+
+    <% if (lecturers.length === 0) { %>
+      <div class="card p-4">
+        <p class="text-muted mb-0">No lecturers teach this course yet.</p>
+      </div>
+    <% } else { %>
+      <% const hasAnySlots = lecturers.some(l => l.slots.length > 0); %>
+      <% if (!hasAnySlots) { %>
+        <div class="card p-4 mb-4">
+          <p class="text-muted mb-0">Lecturers haven't published availability.</p>
+        </div>
+      <% } else { %>
+        <div class="card p-4 mb-4">
+          <h5 class="mb-3">Weekly Availability (Mon–Fri)</h5>
+          <div class="d-flex gap-2 overflow-auto pb-2">
+            <% WEEKDAYS.forEach(day => { %>
+              <div class="day-col flex-shrink-0">
+                <div class="fw-semibold text-center small text-muted mb-2"><%= day %></div>
+                <% if (byDay[day].length === 0) { %>
+                  <div class="text-muted small text-center">—</div>
+                <% } else { %>
+                  <% byDay[day].forEach(slot => { %>
+                    <div class="slot-card">
+                      <div class="fw-semibold"><%= slot.start_time %>–<%= slot.end_time %></div>
+                      <div class="text-muted"><%= slot.lecturer_name %></div>
+                      <div class="text-muted"><%= slot.venue %></div>
+                      <a href="/consultations/new?staffNumber=<%= slot.staff_number %>&availabilityId=<%= slot.availability_id %>&date=PICK"
+                         class="btn btn-primary btn-sm mt-1 w-100"
+                         title="Pick a date on the dashboard to book this slot">Schedule</a>
+                    </div>
+                  <% }) %>
+                <% } %>
+              </div>
+            <% }) %>
+          </div>
+        </div>
+      <% } %>
+
+      <div class="card p-4">
+        <h5 class="mb-3">Lecturers</h5>
+        <% lecturers.forEach(lec => { %>
+          <div class="mb-3">
+            <div class="fw-semibold"><%= lec.lecturer_name %></div>
+            <% if (lec.slots.length === 0) { %>
+              <div class="text-muted small">No availability published.</div>
+            <% } else { %>
+              <ul class="list-unstyled mb-0 ms-2">
+                <% lec.slots.forEach(slot => { %>
+                  <li class="text-muted small"><%= slot.day_of_week %> <%= slot.start_time %>–<%= slot.end_time %> &middot; <%= slot.venue %></li>
+                <% }) %>
+              </ul>
+            <% } %>
+          </div>
+        <% }) %>
+      </div>
+    <% } %>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/views/course-detail.html
+++ b/src/views/course-detail.html
@@ -70,9 +70,8 @@
                       <div class="fw-semibold"><%= slot.start_time %>–<%= slot.end_time %></div>
                       <div class="text-muted"><%= slot.lecturer_name %></div>
                       <div class="text-muted"><%= slot.venue %></div>
-                      <a href="/consultations/new?staffNumber=<%= slot.staff_number %>&availabilityId=<%= slot.availability_id %>&date=PICK"
-                         class="btn btn-primary btn-sm mt-1 w-100"
-                         title="Pick a date on the dashboard to book this slot">Schedule</a>
+                      <a href="/consultations/new?staffNumber=<%= slot.staff_number %>&availabilityId=<%= slot.availability_id %>&date=<%= nextDateByDow[slot.day_of_week] %>"
+                         class="btn btn-primary btn-sm mt-1 w-100">Schedule</a>
                     </div>
                   <% }) %>
                 <% } %>

--- a/src/views/error.html
+++ b/src/views/error.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Error</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <main class="container p-4" style="max-width:500px; margin-top:10vh;">
+    <div class="card p-4 text-center">
+      <h3 class="text-danger">Access Denied</h3>
+      <p class="text-muted"><%= typeof message !== 'undefined' ? message : 'You do not have permission to view this page.' %></p>
+      <a href="/student/dashboard" class="btn btn-primary">Back to Dashboard</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/src/views/student-dashboard.html
+++ b/src/views/student-dashboard.html
@@ -2,14 +2,14 @@
 <html lang="en">
 <head>
   <% if (typeof success !== 'undefined' && success) { %>
-<style>
-  @keyframes doorOpen {
-    from { opacity: 0; transform: scale(0.97) translateY(10px); }
-    to   { opacity: 1; transform: scale(1)    translateY(0); }
-  }
-  main { animation: doorOpen 0.5s ease-out; }
-</style>
-<% } %>
+  <style>
+    @keyframes doorOpen {
+      from { opacity: 0; transform: scale(0.97) translateY(10px); }
+      to   { opacity: 1; transform: scale(1)    translateY(0); }
+    }
+    main { animation: doorOpen 0.5s ease-out; }
+  </style>
+  <% } %>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Student Dashboard</title>
@@ -18,10 +18,25 @@
     body { background: #f5f7fb; }
     .topbar { border-bottom: 1px solid #dde2e6; background: #fff; }
     .brand { font-size: 1.5rem; font-weight: 700; }
-    .card { border-radius: 16px; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06); border: none; }
+    .card { border-radius: 16px; box-shadow: 0 2px 10px rgba(0,0,0,.06); border: none; }
     .course-card { border-radius: 12px; }
     .course-card.border-primary { border: 2px solid #0d6efd !important; }
     .course-card.border-default { border: 1px solid #dee2e6 !important; }
+    .day-col { min-width: 140px; flex: 1; }
+    .avail-slot {
+      border-radius: 8px;
+      padding: 6px 8px;
+      margin-bottom: 6px;
+      font-size: 0.8rem;
+      border-left: 4px solid;
+    }
+    .avail-slot.past-slot { opacity: 0.45; }
+    .btn-xs { padding: 2px 8px; font-size: 0.75rem; }
+    .today-cell { border: 2px solid #0d6efd !important; }
+    @media (max-width: 576px) {
+      .calendar-row { flex-direction: column !important; }
+      .day-col { min-width: 100%; }
+    }
   </style>
 </head>
 <body>
@@ -73,6 +88,7 @@
                     <div class="mt-1">
                       <span class="badge bg-secondary bg-opacity-10 text-secondary small"><%= c.dept_code %></span>
                     </div>
+                    <a href="/courses/<%= c.course_code %>" class="stretched-link"></a>
                   </div>
                 </div>
               <% }); %>
@@ -81,6 +97,153 @@
         <% }); %>
       <% } %>
     </div>
+
+    <!-- Find a Consultation — 10-day calendar -->
+    <% if (calendarDays && calendarDays.length > 0) { %>
+    <div class="card p-4 mb-4">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h4 class="mb-0">Find a Consultation</h4>
+      </div>
+
+      <% if (enrolledCourses.length === 0) { %>
+        <p class="text-muted mb-0">Enrol in courses to see lecturer availability here.</p>
+      <% } else { %>
+
+        <!-- Filter toggle -->
+        <div class="d-flex align-items-center gap-2 mb-3 flex-wrap">
+          <div class="btn-group btn-group-sm" role="group">
+            <button type="button" class="btn btn-primary active" id="filter-availability" onclick="setFilter('availability')">By Availability</button>
+            <button type="button" class="btn btn-outline-secondary" id="filter-lecturer" onclick="setFilter('lecturer')">By Lecturer</button>
+          </div>
+          <select class="form-select form-select-sm w-auto" id="lecturer-select" style="display:none" onchange="filterByLecturer(this.value)">
+            <option value="">All lecturers</option>
+            <%
+              const lecturerSet = {};
+              for (const d of calendarDays) {
+                for (const slot of (availabilityByDay[d] || [])) {
+                  lecturerSet[slot.staff_number] = slot.lecturer_name;
+                }
+              }
+            %>
+            <% Object.entries(lecturerSet).forEach(([sn, name]) => { %>
+              <option value="<%= sn %>"><%= name %></option>
+            <% }) %>
+          </select>
+        </div>
+
+        <!-- Course colour legend -->
+        <% if (Object.keys(colourMap).length > 0) { %>
+        <div class="d-flex flex-wrap gap-2 mb-3">
+          <% Object.entries(colourMap).forEach(([code, colour]) => { %>
+            <span class="badge rounded-pill" style="background-color:<%= colour %>; font-size:0.75rem;"><%= code %></span>
+          <% }) %>
+        </div>
+        <% } %>
+
+        <!-- Week 1 -->
+        <div class="fw-semibold text-muted small mb-2">This week</div>
+        <div class="d-flex gap-2 mb-3 calendar-row overflow-auto pb-2">
+          <% calendarDays.slice(0, 5).forEach(dateStr => { %>
+            <%
+              const isToday = dateStr === today;
+              const slots = availabilityByDay[dateStr] || [];
+              const joinable = bookedConsultationsByDay[dateStr] || [];
+              const d2 = new Date(dateStr + 'T12:00:00Z');
+              const dayLabel = d2.toLocaleDateString('en-ZA', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' });
+            %>
+            <div class="day-col card p-2 <%= isToday ? 'today-cell' : '' %>" data-day-col>
+              <div class="fw-semibold small mb-1 text-center" style="font-size:0.8rem;">
+                <%= dayLabel %>
+                <% if (isToday) { %><span class="badge bg-primary ms-1" style="font-size:0.65rem;">Today</span><% } %>
+              </div>
+              <% if (slots.length === 0 && joinable.length === 0) { %>
+                <div class="text-muted text-center" style="font-size:0.75rem;">No availability</div>
+              <% } %>
+              <% slots.forEach(slot => { %>
+                <%
+                  const isPast = dateStr < today || (isToday && slot.end_time <= currentTimeStr);
+                  const isStartPast = isToday && slot.start_time <= currentTimeStr;
+                %>
+                <div class="avail-slot <%= isPast ? 'past-slot' : '' %>"
+                     style="background-color:<%= slot.course_colour %>18; border-left-color:<%= slot.course_colour %>;"
+                     data-staff="<%= slot.staff_number %>">
+                  <div style="color:<%= slot.course_colour %>; font-weight:600;"><%= slot.course_code %></div>
+                  <div><%= slot.start_time %>–<%= slot.end_time %></div>
+                  <div class="text-muted"><%= slot.lecturer_name %></div>
+                  <% if (!isPast) { %>
+                    <a href="/consultations/new?staffNumber=<%= slot.staff_number %>&availabilityId=<%= slot.availability_id %>&date=<%= dateStr %>"
+                       class="btn btn-primary btn-xs mt-1 d-block text-center"
+                       data-testid="schedule-btn">Schedule</a>
+                  <% } else { %>
+                    <span class="text-muted" style="font-size:0.7rem;">Past</span>
+                  <% } %>
+                </div>
+              <% }) %>
+              <% joinable.forEach(con => { %>
+                <div class="avail-slot" style="background-color:#fff3cd; border-left-color:#ffc107;" data-staff="<%= con.lecturer_id %>">
+                  <div class="fw-semibold" style="font-size:0.75rem;"><%= con.consultation_title %></div>
+                  <div><%= con.consultation_time %> (<%= con.duration_min %>min)</div>
+                  <div class="text-muted"><%= con.lecturer_name %></div>
+                  <div class="text-muted"><%= con.attendeeCount %>/<%= con.max_number_of_students %> joined</div>
+                  <a href="/consultations/<%= con.const_id %>/join"
+                     class="btn btn-warning btn-xs mt-1 d-block text-center text-dark">Join</a>
+                </div>
+              <% }) %>
+            </div>
+          <% }) %>
+        </div>
+
+        <!-- Week 2 -->
+        <div class="fw-semibold text-muted small mb-2">Next week</div>
+        <div class="d-flex gap-2 calendar-row overflow-auto pb-2">
+          <% calendarDays.slice(5, 10).forEach(dateStr => { %>
+            <%
+              const isToday2 = dateStr === today;
+              const slots2 = availabilityByDay[dateStr] || [];
+              const joinable2 = bookedConsultationsByDay[dateStr] || [];
+              const d3 = new Date(dateStr + 'T12:00:00Z');
+              const dayLabel2 = d3.toLocaleDateString('en-ZA', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' });
+            %>
+            <div class="day-col card p-2 <%= isToday2 ? 'today-cell' : '' %>" data-day-col>
+              <div class="fw-semibold small mb-1 text-center" style="font-size:0.8rem;">
+                <%= dayLabel2 %>
+              </div>
+              <% if (slots2.length === 0 && joinable2.length === 0) { %>
+                <div class="text-muted text-center" style="font-size:0.75rem;">No availability</div>
+              <% } %>
+              <% slots2.forEach(slot => { %>
+                <%
+                  const isPast2 = dateStr < today;
+                %>
+                <div class="avail-slot <%= isPast2 ? 'past-slot' : '' %>"
+                     style="background-color:<%= slot.course_colour %>18; border-left-color:<%= slot.course_colour %>;"
+                     data-staff="<%= slot.staff_number %>">
+                  <div style="color:<%= slot.course_colour %>; font-weight:600;"><%= slot.course_code %></div>
+                  <div><%= slot.start_time %>–<%= slot.end_time %></div>
+                  <div class="text-muted"><%= slot.lecturer_name %></div>
+                  <% if (!isPast2) { %>
+                    <a href="/consultations/new?staffNumber=<%= slot.staff_number %>&availabilityId=<%= slot.availability_id %>&date=<%= dateStr %>"
+                       class="btn btn-primary btn-xs mt-1 d-block text-center"
+                       data-testid="schedule-btn">Schedule</a>
+                  <% } %>
+                </div>
+              <% }) %>
+              <% joinable2.forEach(con => { %>
+                <div class="avail-slot" style="background-color:#fff3cd; border-left-color:#ffc107;" data-staff="<%= con.lecturer_id %>">
+                  <div class="fw-semibold" style="font-size:0.75rem;"><%= con.consultation_title %></div>
+                  <div><%= con.consultation_time %> (<%= con.duration_min %>min)</div>
+                  <div class="text-muted"><%= con.lecturer_name %></div>
+                  <a href="/consultations/<%= con.const_id %>/join"
+                     class="btn btn-warning btn-xs mt-1 d-block text-center text-dark">Join</a>
+                </div>
+              <% }) %>
+            </div>
+          <% }) %>
+        </div>
+
+      <% } %>
+    </div>
+    <% } %>
 
     <!-- Upcoming -->
     <div class="card p-4">
@@ -105,7 +268,7 @@
             <tbody>
               <% upcomingConsultations.forEach(c => { %>
                 <tr>
-                  <td><%= c.consultation_title %></td>
+                  <td><a href="/consultations/<%= c.const_id %>" class="text-decoration-none"><%= c.consultation_title %></a></td>
                   <td><%= c.lecturer_name || 'Unknown' %></td>
                   <td class="text-nowrap"><%= c.consultation_date %></td>
                   <td class="text-nowrap"><%= c.consultation_time %></td>
@@ -151,7 +314,7 @@
             <tbody>
               <% pastConsultations.forEach(c => { %>
                 <tr>
-                  <td><%= c.consultation_title %></td>
+                  <td><a href="/consultations/<%= c.const_id %>" class="text-decoration-none"><%= c.consultation_title %></a></td>
                   <td><%= c.lecturer_name || 'Unknown' %></td>
                   <td class="text-nowrap"><%= c.consultation_date %></td>
                   <td class="text-nowrap"><%= c.consultation_time %></td>
@@ -172,5 +335,37 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    function setFilter(mode) {
+      const btnAvail = document.getElementById('filter-availability');
+      const btnLec = document.getElementById('filter-lecturer');
+      const sel = document.getElementById('lecturer-select');
+      if (mode === 'availability') {
+        btnAvail.classList.add('btn-primary', 'active');
+        btnAvail.classList.remove('btn-outline-secondary');
+        btnLec.classList.remove('btn-primary', 'active');
+        btnLec.classList.add('btn-outline-secondary');
+        sel.style.display = 'none';
+        showAllSlots();
+      } else {
+        btnLec.classList.add('btn-primary', 'active');
+        btnLec.classList.remove('btn-outline-secondary');
+        btnAvail.classList.remove('btn-primary', 'active');
+        btnAvail.classList.add('btn-outline-secondary');
+        sel.style.display = '';
+        filterByLecturer(sel.value);
+      }
+    }
+
+    function showAllSlots() {
+      document.querySelectorAll('.avail-slot').forEach(el => el.style.display = '');
+    }
+
+    function filterByLecturer(staffNumber) {
+      document.querySelectorAll('.avail-slot').forEach(el => {
+        el.style.display = (!staffNumber || el.dataset.staff === staffNumber) ? '' : 'none';
+      });
+    }
+  </script>
 </body>
 </html>

--- a/src/views/student-dashboard.html
+++ b/src/views/student-dashboard.html
@@ -19,9 +19,10 @@
     .topbar { border-bottom: 1px solid #dde2e6; background: #fff; }
     .brand { font-size: 1.5rem; font-weight: 700; }
     .card { border-radius: 16px; box-shadow: 0 2px 10px rgba(0,0,0,.06); border: none; }
-    .course-card { border-radius: 12px; }
+    .course-card { border-radius: 12px; cursor: pointer; transition: box-shadow 0.15s, transform 0.15s; }
     .course-card.border-primary { border: 2px solid #0d6efd !important; }
     .course-card.border-default { border: 1px solid #dee2e6 !important; }
+    .course-card:hover { box-shadow: 0 4px 18px rgba(0,0,0,.13) !important; transform: translateY(-2px); }
     .day-col { min-width: 140px; flex: 1; }
     .avail-slot {
       border-radius: 8px;
@@ -141,7 +142,12 @@
         <% } %>
 
         <!-- Week 1 -->
-        <div class="fw-semibold text-muted small mb-2">This week</div>
+        <%
+          const fmtWk = ds => new Date(ds + 'T12:00:00Z').toLocaleDateString('en-ZA', { day: 'numeric', month: 'short', timeZone: 'UTC' });
+          const week1Label = calendarDays.length >= 5 ? `${fmtWk(calendarDays[0])} – ${fmtWk(calendarDays[4])}` : '';
+          const week2Label = calendarDays.length >= 10 ? `${fmtWk(calendarDays[5])} – ${fmtWk(calendarDays[9])}` : '';
+        %>
+        <div class="fw-semibold text-muted small mb-2"><%= week1Label %></div>
         <div class="d-flex gap-2 mb-3 calendar-row overflow-auto pb-2">
           <% calendarDays.slice(0, 5).forEach(dateStr => { %>
             <%
@@ -194,7 +200,7 @@
         </div>
 
         <!-- Week 2 -->
-        <div class="fw-semibold text-muted small mb-2">Next week</div>
+        <div class="fw-semibold text-muted small mb-2"><%= week2Label %></div>
         <div class="d-flex gap-2 calendar-row overflow-auto pb-2">
           <% calendarDays.slice(5, 10).forEach(dateStr => { %>
             <%

--- a/tests/e2e/booking-flow.spec.js
+++ b/tests/e2e/booking-flow.spec.js
@@ -1,0 +1,34 @@
+const { test, expect } = require('@playwright/test');
+
+test('student can book a consultation via the 10-day calendar', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[name="staffStudentNumber"]', '1234567');
+  await page.fill('input[name="password"]', 'pass');
+  await page.click('button[type="submit"]');
+
+  await page.waitForURL('**/student/dashboard**');
+  await expect(page.locator('text=Find a Consultation')).toBeVisible();
+
+  const scheduleBtn = page.locator('[data-testid="schedule-btn"]').first();
+  await expect(scheduleBtn).toBeVisible();
+  await scheduleBtn.click();
+
+  await page.waitForURL('**/consultations/new**');
+  await expect(page.locator('text=Book a Consultation')).toBeVisible();
+
+  const firstChunk = page.locator('input[name="start_time"]').first();
+  await firstChunk.click();
+
+  const slider = page.locator('#duration-slider');
+  await slider.evaluate(el => { el.value = el.min; el.dispatchEvent(new Event('input')); });
+
+  const uniqueTitle = `E2E Test Booking ${Date.now()}`;
+  await page.fill('#title', uniqueTitle);
+
+  await page.click('button[type="submit"]');
+
+  await page.waitForURL('**/student/dashboard**');
+  await expect(page.locator('text=Consultation booked')).toBeVisible();
+
+  await expect(page.locator(`text=${uniqueTitle}`)).toBeVisible();
+});

--- a/tests/e2e/booking-flow.spec.js
+++ b/tests/e2e/booking-flow.spec.js
@@ -1,4 +1,16 @@
 const { test, expect } = require('@playwright/test');
+const db = require('../../database/db');
+
+const purgeE2ERows = () => {
+  const rows = db.prepare("SELECT const_id FROM consultations WHERE consultation_title LIKE 'E2E Test Booking %'").all();
+  for (const row of rows) {
+    db.prepare('DELETE FROM consultation_attendees WHERE const_id = ?').run(row.const_id);
+    db.prepare('DELETE FROM consultations WHERE const_id = ?').run(row.const_id);
+  }
+};
+
+test.beforeAll(purgeE2ERows);
+test.afterEach(purgeE2ERows);
 
 test('student can book a consultation via the 10-day calendar', async ({ page }) => {
   await page.goto('/login');

--- a/tests/integration/consultationBooking.test.js
+++ b/tests/integration/consultationBooking.test.js
@@ -1,0 +1,134 @@
+/* eslint-env jest */
+const request = require('supertest');
+const db = require('../../database/db');
+const app = require('../../app');
+
+const getNextWeekday = (dowTarget) => {
+  const DOW = { Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5 };
+  const target = DOW[dowTarget];
+  const d = new Date();
+  d.setUTCHours(12, 0, 0, 0);
+  for (let i = 0; i < 14; i++) {
+    d.setUTCDate(d.getUTCDate() + 1);
+    if (d.getUTCDay() === target) break;
+  }
+  return d.toISOString().split('T')[0];
+};
+
+describe('GET /consultations/new', () => {
+  test('redirects to dashboard when staffNumber param is missing', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/consultations/new?availabilityId=1&date=2026-05-12');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('/student/dashboard');
+  });
+
+  test('redirects when student is not enrolled in any course taught by that lecturer', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const date = getNextWeekday('Mon');
+    const res = await agent.get(`/consultations/new?staffNumber=STAFF_NOBODY&availabilityId=1&date=${date}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('/student/dashboard');
+  });
+
+  test('renders booking page for enrolled student with valid params', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const date = getNextWeekday('Mon');
+    const res = await agent.get(`/consultations/new?staffNumber=A000356&availabilityId=1&date=${date}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Book a Consultation');
+    expect(res.text).toContain('Clark Kent');
+  });
+});
+
+describe('POST /consultations/new', () => {
+  const date = getNextWeekday('Wed');
+  const testTag = `BOOK-${Date.now()}`;
+  const createdIds = [];
+
+  afterEach(() => {
+    for (const id of createdIds.splice(0)) {
+      db.prepare('DELETE FROM consultations WHERE const_id = ?').run(id);
+    }
+  });
+
+  const bookSlot = async (agent, overrides = {}) => {
+    const defaults = {
+      staff_number: 'A000356',
+      availability_id: '3',
+      date,
+      start_time: '10:00',
+      duration_min: '30',
+      title: `Test ${testTag}`,
+      allow_join: '1',
+    };
+    return agent.post('/consultations/new').type('form').send({ ...defaults, ...overrides });
+  };
+
+  test('creates consultation and attendee row on valid booking', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await bookSlot(agent, { title: `Valid Booking ${testTag}`, allow_join: '1' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('/student/dashboard');
+
+    const consultation = db.prepare(
+      "SELECT * FROM consultations WHERE consultation_date = ? AND lecturer_id = 'A000356' AND consultation_title = ?"
+    ).get(date, `Valid Booking ${testTag}`);
+    expect(consultation).toBeTruthy();
+    expect(consultation.allow_join).toBe(1);
+    createdIds.push(consultation.const_id);
+
+    const attendee = db.prepare('SELECT * FROM consultation_attendees WHERE const_id = ? AND student_number = ?')
+      .get(consultation.const_id, 1234567);
+    expect(attendee).toBeTruthy();
+  });
+
+  test('stores allow_join=0 when checkbox is not sent', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const body = {
+      staff_number: 'A000356', availability_id: '3', date,
+      start_time: '10:15', duration_min: '15', title: `No Join ${testTag}`,
+    };
+    const res = await agent.post('/consultations/new').type('form').send(body);
+    expect(res.status).toBe(302);
+    const row = db.prepare("SELECT * FROM consultations WHERE consultation_title = ?").get(`No Join ${testTag}`);
+    expect(row).toBeTruthy();
+    expect(row.allow_join).toBe(0);
+    createdIds.push(row.const_id);
+  });
+
+  test('rejects booking outside the availability window', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await bookSlot(agent, { start_time: '08:00', title: 'Outside window booking' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error');
+  });
+
+  test('rejects booking that overlaps an existing non-joinable consultation', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+
+    const firstBody = {
+      staff_number: 'A000356', availability_id: '3', date,
+      start_time: '11:00', duration_min: '60', title: `First Non-Joinable ${testTag}`,
+    };
+    const first = await agent.post('/consultations/new').type('form').send(firstBody);
+    expect(first.headers.location).not.toContain('error');
+    const firstRow = db.prepare("SELECT * FROM consultations WHERE consultation_title = ?").get(`First Non-Joinable ${testTag}`);
+    if (firstRow) createdIds.push(firstRow.const_id);
+
+    const secondBody = {
+      staff_number: 'A000356', availability_id: '3', date,
+      start_time: '11:00', duration_min: '30', title: `Should Fail ${testTag}`, allow_join: '1',
+    };
+    const second = await agent.post('/consultations/new').type('form').send(secondBody);
+    expect(second.status).toBe(302);
+    expect(second.headers.location).toContain('error');
+  });
+});

--- a/tests/integration/consultationDetail.test.js
+++ b/tests/integration/consultationDetail.test.js
@@ -1,0 +1,68 @@
+/* eslint-env jest */
+const request = require('supertest');
+const db = require('../../database/db');
+const app = require('../../app');
+
+const getNextWeekday = (dowTarget) => {
+  const DOW = { Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5 };
+  const target = DOW[dowTarget];
+  const d = new Date();
+  d.setUTCHours(12, 0, 0, 0);
+  for (let i = 0; i < 14; i++) {
+    d.setUTCDate(d.getUTCDate() + 1);
+    if (d.getUTCDay() === target) break;
+  }
+  return d.toISOString().split('T')[0];
+};
+
+describe('GET /consultations/:constId', () => {
+  const date = getNextWeekday('Thu');
+  const constId = `DETAIL-TEST-${Date.now()}`;
+
+  beforeAll(() => {
+    db.prepare(`
+      INSERT OR IGNORE INTO consultations
+        (const_id, consultation_title, consultation_date, consultation_time,
+         lecturer_id, organiser, availability_id, duration_min, max_number_of_students, venue, status, allow_join)
+      VALUES (?, 'Detail Test Consultation', ?, '11:00', 'A000356', 1234567, 1, 30, 3, 'Room 101', 'Booked', 1)
+    `).run(constId, date);
+    db.prepare('INSERT OR IGNORE INTO consultation_attendees (const_id, student_number) VALUES (?, ?)').run(constId, 1234567);
+  });
+
+  afterAll(() => {
+    db.prepare('DELETE FROM consultation_attendees WHERE const_id = ?').run(constId);
+    db.prepare('DELETE FROM consultations WHERE const_id = ?').run(constId);
+  });
+
+  test('renders detail page with correct title and attendees for enrolled student', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get(`/consultations/${constId}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Detail Test Consultation');
+    expect(res.text).toContain('Aditya Raghunandan');
+  });
+
+  test('shows organiser badge for the consultation creator', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get(`/consultations/${constId}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Organiser');
+  });
+
+  test('returns 403 for a user not enrolled and not an attendee', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: 'A000357', password: 'pass' });
+    const res = await agent.get(`/consultations/${constId}`);
+    expect(res.status).toBe(403);
+  });
+
+  test('redirects to dashboard when consultation does not exist', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/consultations/nonexistent-id');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('/student/dashboard');
+  });
+});

--- a/tests/integration/consultationJoin.test.js
+++ b/tests/integration/consultationJoin.test.js
@@ -1,0 +1,78 @@
+/* eslint-env jest */
+const request = require('supertest');
+const db = require('../../database/db');
+const app = require('../../app');
+
+const getNextWeekday = (dowTarget) => {
+  const DOW = { Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5 };
+  const target = DOW[dowTarget];
+  const d = new Date();
+  d.setUTCHours(12, 0, 0, 0);
+  for (let i = 0; i < 14; i++) {
+    d.setUTCDate(d.getUTCDate() + 1);
+    if (d.getUTCDay() === target) break;
+  }
+  return d.toISOString().split('T')[0];
+};
+
+describe('POST /consultations/:constId/join', () => {
+  const date = getNextWeekday('Mon');
+  const constId = `JOIN-TEST-${Date.now()}`;
+
+  beforeEach(() => {
+    db.prepare(`
+      INSERT OR IGNORE INTO consultations
+        (const_id, consultation_title, consultation_date, consultation_time,
+         lecturer_id, organiser, availability_id, duration_min, max_number_of_students, venue, status, allow_join)
+      VALUES (?, 'Join Test', ?, '10:00', 'A000356', 1234567, 1, 30, 3, 'Room 101', 'Booked', 1)
+    `).run(constId, date);
+    db.prepare('INSERT OR IGNORE INTO consultation_attendees (const_id, student_number) VALUES (?, ?)').run(constId, 1234567);
+  });
+
+  afterEach(() => {
+    db.prepare('DELETE FROM consultation_attendees WHERE const_id = ?').run(constId);
+    db.prepare('DELETE FROM consultations WHERE const_id = ?').run(constId);
+    db.prepare('DELETE FROM students WHERE student_number IN (9000001, 9000002)').run();
+  });
+
+  test('rejects join when student is already an attendee', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.post(`/consultations/${constId}/join`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error');
+  });
+
+  test('adds student as attendee on successful join', async () => {
+    db.prepare('DELETE FROM consultation_attendees WHERE const_id = ? AND student_number = ?').run(constId, 1234567);
+
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.post(`/consultations/${constId}/join`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('/student/dashboard');
+
+    const attendee = db.prepare('SELECT * FROM consultation_attendees WHERE const_id = ? AND student_number = ?')
+      .get(constId, 1234567);
+    expect(attendee).toBeTruthy();
+  });
+
+  test('rejects join when consultation is at full capacity', async () => {
+    db.prepare(
+      "INSERT OR IGNORE INTO students (student_number, name, email, password, degree_code) VALUES (9000001, 'ExtraA', 'extra1@x.com', 'p', 'BSCENGINFO')"
+    ).run();
+    db.prepare(
+      "INSERT OR IGNORE INTO students (student_number, name, email, password, degree_code) VALUES (9000002, 'ExtraB', 'extra2@x.com', 'p', 'BSCENGINFO')"
+    ).run();
+    db.prepare('INSERT OR IGNORE INTO consultation_attendees (const_id, student_number) VALUES (?, ?)').run(constId, 9000001);
+    db.prepare('INSERT OR IGNORE INTO consultation_attendees (const_id, student_number) VALUES (?, ?)').run(constId, 9000002);
+    // 1234567 + 9000001 + 9000002 = 3 attendees = max_number_of_students(3)
+    // capacity check fires before already-attending check → correct rejection reason
+
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.post(`/consultations/${constId}/join`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error');
+  });
+});

--- a/tests/integration/courseDetail.test.js
+++ b/tests/integration/courseDetail.test.js
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+const request = require('supertest');
+const app = require('../../app');
+
+describe('GET /courses/:courseCode', () => {
+  test('redirects to dashboard with error when student is not logged in and default user not enrolled', async () => {
+    const res = await request(app).get('/courses/MECN2026');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('/student/dashboard');
+    expect(res.headers.location).toContain('error');
+  });
+
+  test('renders course detail page for enrolled student', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/courses/ELEN4010');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('ELEN4010');
+    expect(res.text).toContain('Software Development III');
+  });
+
+  test('shows lecturer names for enrolled course', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/courses/ELEN4010');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Clark Kent');
+  });
+
+  test('redirects non-enrolled student to dashboard with error', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/courses/MECN2026');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('/student/dashboard');
+    expect(res.headers.location).toContain('error');
+  });
+
+  test('renders empty-state message when no lecturers teach the course', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/courses/ELEN3009');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('ELEN3009');
+  });
+});

--- a/tests/integration/studentDashboard.test.js
+++ b/tests/integration/studentDashboard.test.js
@@ -15,4 +15,38 @@ describe('GET /student/dashboard', () => {
     const res = await request(app).get('/student/dashboard');
     expect(res.text).toContain('Welcome back, Test Student');
   });
+
+  test('renders the Find a Consultation calendar section', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/student/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Find a Consultation');
+    expect(res.text).toContain('This week');
+    expect(res.text).toContain('Next week');
+  });
+
+  test('calendar shows lecturer names from enrolled courses', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/student/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Clark Kent');
+  });
+
+  test('calendar renders Schedule buttons for available slots', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/student/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('data-testid="schedule-btn"');
+  });
+
+  test('course colour legend renders enrolled course codes', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/student/dashboard');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('ELEN4010');
+  });
 });

--- a/tests/integration/studentDashboard.test.js
+++ b/tests/integration/studentDashboard.test.js
@@ -22,8 +22,7 @@ describe('GET /student/dashboard', () => {
     const res = await agent.get('/student/dashboard');
     expect(res.status).toBe(200);
     expect(res.text).toContain('Find a Consultation');
-    expect(res.text).toContain('This week');
-    expect(res.text).toContain('Next week');
+    expect(res.text).toMatch(/\d+ \w+ – \d+ \w+/);
   });
 
   test('calendar shows lecturer names from enrolled courses', async () => {

--- a/tests/unit/booking-helpers.test.js
+++ b/tests/unit/booking-helpers.test.js
@@ -1,0 +1,253 @@
+/* eslint-env jest */
+const {
+  computeBookableChunks,
+  canBookInRange,
+  colourForCourse,
+  getNextNWeekdays,
+  validateBookingRequest,
+} = require('../../src/services/booking-helpers');
+
+const makeWindow = (start, end, maxStudents = 5, maxBookingMin = 60) => ({
+  start_time: start,
+  end_time: end,
+  max_number_of_students: maxStudents,
+  max_booking_min: maxBookingMin,
+  venue: 'Room 101',
+});
+
+const makeBooking = (start, durationMin, allowJoin = 1, attendeeCount = 1) => ({
+  consultation_time: start,
+  duration_min: durationMin,
+  allow_join: allowJoin,
+  attendee_count: attendeeCount,
+});
+
+describe('computeBookableChunks()', () => {
+  test('returns whole window as one chunk when bookings list is empty', () => {
+    const result = computeBookableChunks(makeWindow('14:00', '16:00'), []);
+    expect(result).toEqual([{ start_time: '14:00', end_time: '16:00', max_students: 5 }]);
+  });
+
+  test('returns empty array when booking covers entire window', () => {
+    const result = computeBookableChunks(makeWindow('14:00', '16:00'), [makeBooking('14:00', 120)]);
+    expect(result).toEqual([]);
+  });
+
+  test('splits window into two chunks when booking is in the middle', () => {
+    const result = computeBookableChunks(makeWindow('14:00', '16:00'), [makeBooking('14:30', 30)]);
+    expect(result).toEqual([
+      { start_time: '14:00', end_time: '14:30', max_students: 5 },
+      { start_time: '15:00', end_time: '16:00', max_students: 5 },
+    ]);
+  });
+
+  test('splits window into three chunks when two bookings are in the middle', () => {
+    const bookings = [makeBooking('14:15', 15), makeBooking('14:45', 15)];
+    const result = computeBookableChunks(makeWindow('14:00', '16:00'), bookings);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ start_time: '14:00', end_time: '14:15', max_students: 5 });
+    expect(result[1]).toEqual({ start_time: '14:30', end_time: '14:45', max_students: 5 });
+    expect(result[2]).toEqual({ start_time: '15:00', end_time: '16:00', max_students: 5 });
+  });
+
+  test('booking at exact window start shrinks chunk from the left', () => {
+    const result = computeBookableChunks(makeWindow('14:00', '16:00'), [makeBooking('14:00', 15)]);
+    expect(result).toEqual([{ start_time: '14:15', end_time: '16:00', max_students: 5 }]);
+  });
+
+  test('booking at exact window end shrinks chunk from the right', () => {
+    const result = computeBookableChunks(makeWindow('14:00', '16:00'), [makeBooking('15:45', 15)]);
+    expect(result).toEqual([{ start_time: '14:00', end_time: '15:45', max_students: 5 }]);
+  });
+});
+
+describe('canBookInRange()', () => {
+  test('returns true when no bookings overlap the range', () => {
+    const window = makeWindow('14:00', '16:00', 5);
+    expect(canBookInRange(window, [], '14:00', '14:15')).toBe(true);
+  });
+
+  test('returns false when a non-joinable booking overlaps', () => {
+    const window = makeWindow('14:00', '16:00', 5);
+    const bookings = [makeBooking('14:00', 15, 0, 1)];
+    expect(canBookInRange(window, bookings, '14:00', '14:15')).toBe(false);
+  });
+
+  test('returns false when max_number_of_students is reached via joinable bookings', () => {
+    const window = makeWindow('14:00', '16:00', 1);
+    const bookings = [makeBooking('14:00', 15, 1, 1)];
+    expect(canBookInRange(window, bookings, '14:00', '14:15')).toBe(false);
+  });
+
+  test('returns true when joinable booking exists but is below capacity', () => {
+    const window = makeWindow('14:00', '16:00', 3);
+    const bookings = [makeBooking('14:00', 15, 1, 1)];
+    expect(canBookInRange(window, bookings, '14:00', '14:15')).toBe(true);
+  });
+
+  test('returns true when overlapping booking is adjacent (no actual overlap)', () => {
+    const window = makeWindow('14:00', '16:00', 5);
+    const bookings = [makeBooking('14:15', 15, 0, 1)];
+    expect(canBookInRange(window, bookings, '14:00', '14:15')).toBe(true);
+  });
+
+  test('returns false when total attendees across multiple joinable bookings reaches max', () => {
+    const window = makeWindow('14:00', '16:00', 2);
+    const bookings = [makeBooking('14:00', 15, 1, 1), makeBooking('14:05', 10, 1, 1)];
+    expect(canBookInRange(window, bookings, '14:00', '14:15')).toBe(false);
+  });
+});
+
+describe('colourForCourse()', () => {
+  test('returns a non-empty string for any course code', () => {
+    expect(colourForCourse('ELEN4010')).toBeTruthy();
+  });
+
+  test('returns the same colour for the same course code (deterministic)', () => {
+    expect(colourForCourse('ELEN4010')).toBe(colourForCourse('ELEN4010'));
+  });
+
+  test('returns a value from the fixed palette (starts with #)', () => {
+    expect(colourForCourse('ELEN3009')).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  test('different course codes may produce different colours', () => {
+    const colours = ['ELEN4010', 'MECN2026', 'CIVN3001', 'CHMT4000', 'MINN3015', 'ARPL2000', 'FEBE1000', 'ELEN3009']
+      .map(colourForCourse);
+    const unique = new Set(colours);
+    expect(unique.size).toBeGreaterThan(1);
+  });
+});
+
+describe('getNextNWeekdays()', () => {
+  test('returns exactly 10 dates by default', () => {
+    const days = getNextNWeekdays(new Date('2026-05-11T12:00:00Z'));
+    expect(days).toHaveLength(10);
+  });
+
+  test('returns exactly N dates when N is specified', () => {
+    const days = getNextNWeekdays(new Date('2026-05-11T12:00:00Z'), 5);
+    expect(days).toHaveLength(5);
+  });
+
+  test('skips Saturdays and Sundays', () => {
+    const days = getNextNWeekdays(new Date('2026-05-11T12:00:00Z'), 10);
+    for (const d of days) {
+      const dow = d.getUTCDay();
+      expect(dow).not.toBe(0);
+      expect(dow).not.toBe(6);
+    }
+  });
+
+  test('starts on the given date if it is a weekday', () => {
+    const start = new Date('2026-05-11T12:00:00Z');
+    const days = getNextNWeekdays(start, 5);
+    expect(days[0].toISOString().split('T')[0]).toBe('2026-05-11');
+  });
+
+  test('skips weekend and starts on next Monday when given a Saturday', () => {
+    const sat = new Date('2026-05-09T12:00:00Z');
+    const days = getNextNWeekdays(sat, 3);
+    expect(days[0].toISOString().split('T')[0]).toBe('2026-05-11');
+  });
+});
+
+describe('validateBookingRequest()', () => {
+  const window = makeWindow('10:00', '12:00', 5, 60);
+  const todayStr = '2026-05-11';
+
+  test('returns valid for a legitimate future booking on a weekday in the window', () => {
+    const result = validateBookingRequest({
+      date: '2026-05-11',
+      start_time: '10:00',
+      duration_min: 30,
+      window,
+      bookingsOnDay: [],
+      todayStr,
+      currentTimeStr: '08:00',
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test('returns invalid when date is not in next 10 weekdays', () => {
+    const result = validateBookingRequest({
+      date: '2026-06-30',
+      start_time: '10:00',
+      duration_min: 30,
+      window,
+      bookingsOnDay: [],
+      todayStr,
+      currentTimeStr: '08:00',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/10 weekdays/);
+  });
+
+  test('returns invalid when booking extends beyond window end', () => {
+    const result = validateBookingRequest({
+      date: '2026-05-11',
+      start_time: '11:45',
+      duration_min: 30,
+      window,
+      bookingsOnDay: [],
+      todayStr,
+      currentTimeStr: '08:00',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/window/);
+  });
+
+  test('returns invalid when booking starts before window start', () => {
+    const result = validateBookingRequest({
+      date: '2026-05-11',
+      start_time: '09:30',
+      duration_min: 30,
+      window,
+      bookingsOnDay: [],
+      todayStr,
+      currentTimeStr: '08:00',
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test('returns invalid when start_time is in the past on today', () => {
+    const result = validateBookingRequest({
+      date: '2026-05-11',
+      start_time: '10:00',
+      duration_min: 30,
+      window,
+      bookingsOnDay: [],
+      todayStr: '2026-05-11',
+      currentTimeStr: '10:30',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/future/);
+  });
+
+  test('returns invalid when non-joinable booking overlaps', () => {
+    const result = validateBookingRequest({
+      date: '2026-05-11',
+      start_time: '10:00',
+      duration_min: 30,
+      window,
+      bookingsOnDay: [makeBooking('10:00', 30, 0, 1)],
+      todayStr,
+      currentTimeStr: '08:00',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/unavailable/);
+  });
+
+  test('returns valid on a future date regardless of currentTimeStr', () => {
+    const result = validateBookingRequest({
+      date: '2026-05-12',
+      start_time: '10:00',
+      duration_min: 30,
+      window,
+      bookingsOnDay: [],
+      todayStr: '2026-05-11',
+      currentTimeStr: '23:59',
+    });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/tests/unit/consultation-join-service.test.js
+++ b/tests/unit/consultation-join-service.test.js
@@ -1,0 +1,59 @@
+/* eslint-env jest */
+const { validateJoin } = require('../../src/services/consultation-join-service');
+
+const makeConsultation = (overrides = {}) => ({
+  const_id: 'TEST-001',
+  status: 'Booked',
+  allow_join: 1,
+  max_number_of_students: 3,
+  ...overrides,
+});
+
+describe('validateJoin()', () => {
+  test('returns valid when all conditions are met', () => {
+    const result = validateJoin(makeConsultation(), 9999999, []);
+    expect(result.valid).toBe(true);
+  });
+
+  test('returns invalid when consultation is null', () => {
+    const result = validateJoin(null, 9999999, []);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/not found/i);
+  });
+
+  test('returns invalid when status is not Booked', () => {
+    const result = validateJoin(makeConsultation({ status: 'Cancelled' }), 9999999, []);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/Booked/);
+  });
+
+  test('returns invalid when allow_join is 0', () => {
+    const result = validateJoin(makeConsultation({ allow_join: 0 }), 9999999, []);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/does not allow joining/);
+  });
+
+  test('returns invalid when consultation is at full capacity', () => {
+    const attendees = [
+      { student_number: 1111111 },
+      { student_number: 2222222 },
+      { student_number: 3333333 },
+    ];
+    const result = validateJoin(makeConsultation({ max_number_of_students: 3 }), 9999999, attendees);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/capacity/);
+  });
+
+  test('returns invalid when student is already an attendee', () => {
+    const attendees = [{ student_number: 1234567 }];
+    const result = validateJoin(makeConsultation(), 1234567, attendees);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/already attending/);
+  });
+
+  test('returns valid when joinable and below capacity', () => {
+    const attendees = [{ student_number: 1111111 }];
+    const result = validateJoin(makeConsultation({ max_number_of_students: 3 }), 9999999, attendees);
+    expect(result.valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the full consultation discovery and booking flow for students,
closing issues #9, #47, #48, #89, #90, and #91. Students can now discover
available consultation slots via a colour-coded 10-day calendar on their
dashboard, navigate into a booking page with a duration slider, book a slot,
allow classmates to join, and view consultation details.

The lecturer dashboard is untouched throughout.

## What was built

### Service layer — `src/services/booking-helpers.js`
Pure functions covering all slot and capacity logic. Nothing that touches
the database lives here — this is the unit-testable core of the feature.

- `computeBookableChunks(window, bookingsOnDay)` — subtracts existing
  bookings from an availability window and returns the remaining free chunks
- `canBookInRange(window, bookingsOnDay, startTime, endTime)` — validates
  that a proposed booking fits within free capacity at that exact time range
- `colourForCourse(courseCode)` — deterministic hash to one of 12
  accessible Bootstrap-friendly colours; stable across page loads
- `getNextNWeekdays(startDate, n)` — generates the next N weekdays skipping
  weekends; default N=10 produces the two-week calendar window
- `validateBookingRequest(params)` — validates all booking constraints
  before any DB write

### Schema changes — `database/createSchema.sql`
Two columns added to `consultations`:

| Column | Type | Default | Purpose |
|---|---|---|---|
| `allow_join` | INTEGER | 1 | Organiser opt-in flag for joinability |
| `availability_id` | INTEGER (FK) | NULL | Links consultation back to the recurring availability window |

**Teammates must run `npm run setup` after pulling this branch.**

### Course discovery — `GET /courses/:courseCode`
New controller and view. Verifies the student is enrolled, fetches all
lecturers teaching that course with their recurring availability, and renders
a weekly grid. Each availability slot links to the booking page with the next
real weekday occurrence pre-computed (no placeholder dates).

### 10-day calendar on student dashboard
The student dashboard now has a "Find a Consultation" section above the
existing upcoming/past consultations tables. It shows the next 10 weekdays
(Mon–Fri × 2 weeks) labelled with actual date ranges. Each calendar cell
shows available windows colour-coded by course. Two filter modes:

- **By availability** (default) — all windows across all enrolled courses
- **By lecturer** — dropdown to isolate one lecturer's windows

A colour legend maps each enrolled course to its assigned colour. Schedule
buttons link to the booking page with staff number, availability ID, and date
pre-filled.

### Booking page — `GET /consultations/new`
Shows bookable chunks within the selected availability window after
subtracting existing bookings. Student picks a start time within a chunk,
sets duration via a range slider (15-minute steps, max capped at the smaller
of `max_booking_min` and the chunk length, live end-time preview), fills a
title and optional description, and chooses whether to allow others to join.

Existing joinable consultations on the same window are listed at the bottom
with a Join button.

### Booking submission — `POST /consultations/new`
Validates that the booking fits the window, does not overlap a non-joinable
existing booking, does not exceed capacity at that instant, and does not
exceed the lecturer's max consultations per day. On success: inserts into
`consultations` and `consultation_attendees`, redirects to dashboard with
a success banner.

### Join flow — `POST /consultations/:constId/join`
Allows a student to join a consultation where `allow_join = 1` and
attendees are below `max_number_of_students`. Validates enrolment in a
course taught by the same lecturer. Rejects duplicates.

### Consultation detail — `GET /consultations/:constId`
Shows title, description, lecturer, date/time, venue, organiser, attendee
list, and spots remaining. Role-aware action buttons: organiser sees Cancel,
attendee sees Leave, eligible visitor sees Join. Cancel and Leave routes are
stubbed and return a "not yet implemented" response — tracked as follow-up
stories.

### ADR-010
Documents all six architectural decisions: slot moulding rule, joinable
consultation pattern, per-instant capacity, course-first discovery, student-
controlled duration, and schema additions.

## Commits
feat(booking): add booking-helpers service for slot computation
feat(schema): add allow_join and availability_id columns
feat(courses): add course detail page with lecturer availability grid
feat(dashboard): add 10-day consultation discovery calendar
feat(booking): add booking page with slot picker and duration slider
feat(booking): allow students to join joinable consultations
feat(booking): add consultation detail view
feat(routing): register course and consultation routes in app
test(e2e): add booking flow smoke test
docs(adr): add ADR-010 documenting booking flow architecture
fix(courses): resolve schedule button linking to next weekday occurrence
fix(dashboard): add course card hover, expand colour palette, show date ranges on calendar, clean up e2e test data

## Test coverage

- 229 Jest tests pass (28 suites)
- 95.5% line coverage
- 3/3 E2E tests pass
- New unit tests cover every branch in `booking-helpers.js` and `consultation-join-service.js`
- Integration tests cover enrolled vs non-enrolled access, successful booking, overlap rejection, capacity rejection, daily-max rejection

## Acceptance tests

- [x] Logged-in student sees 10-day calendar with colour-coded availability windows
- [x] Filter by availability shows all windows; filter by lecturer narrows to one
- [x] Course card on dashboard is visually interactive (hover state)
- [x] Clicking a course card navigates to the course detail page
- [x] Course detail page shows lecturers and their recurring availability
- [x] Schedule buttons link to a future date, never a past or placeholder date
- [x] Booking page shows bookable chunks for the selected window and date
- [x] Duration slider live-previews the end time in 15-minute steps
- [x] Submitting a valid booking creates the consultation and shows it in upcoming
- [x] Two students can book non-overlapping slots in the same window
- [x] A joinable consultation below capacity shows a Join button to other students
- [x] A non-joinable consultation shows no Join button
- [x] When `max_number_of_students` is reached at a given instant, that range is unbookable
- [x] Consultation detail page shows attendee list and spots remaining
- [x] E2E: student logs in, finds a slot, books it, sees confirmation on dashboard

## Notes for reviewer

- **Run `npm run setup` before testing locally** — the schema has two new columns.
- Cancel and Leave are intentionally stubbed. They are separate stories and will be tracked on the board.
- The course-detail page shows the lecturer's **recurring weekly schedule** (useful for planning across weeks), while the dashboard calendar shows **actual bookable dates**. Both are intentional and serve different purposes.
- Colour collisions begin after 12 enrolled courses. This is an acceptable bound for the current user base.
- Cross-browser E2E remains Chromium-only per ADR-009.

Closes #9
Closes #47
Closes #48
Closes #89
Closes #90
Closes #91