### PR TITLE
Fix/admin crud constraints

### DIFF
--- a/src/controllers/admin-controller.js
+++ b/src/controllers/admin-controller.js
@@ -64,10 +64,10 @@ const showTable = (req, res) => {
   if (search) {
     const { whereClauses, params } = buildSearchQuery(columns, search);
     totalRows = db.prepare(`SELECT COUNT(*) as count FROM "${tableName}" WHERE ${whereClauses}`).get(...params).count;
-    rows = db.prepare(`SELECT rowid, * FROM "${tableName}" WHERE ${whereClauses} LIMIT ? OFFSET ?`).all(...params, PAGE_SIZE, offset);
+    rows = db.prepare(`SELECT *, rowid as rowid FROM "${tableName}" WHERE ${whereClauses} LIMIT ? OFFSET ?`).all(...params, PAGE_SIZE, offset);
   } else {
     totalRows = db.prepare(`SELECT COUNT(*) as count FROM "${tableName}"`).get().count;
-    rows = db.prepare(`SELECT rowid, * FROM "${tableName}" LIMIT ? OFFSET ?`).all(PAGE_SIZE, offset);
+    rows = db.prepare(`SELECT *, rowid as rowid FROM "${tableName}" LIMIT ? OFFSET ?`).all(PAGE_SIZE, offset);
   }
 
   const totalPages = Math.max(1, Math.ceil(totalRows / PAGE_SIZE));
@@ -99,7 +99,7 @@ const createRecord = (req, res) => {
     const inputTypes = getInputTypes(columns);
     const totalRows = db.prepare(`SELECT COUNT(*) as count FROM "${tableName}"`).get().count;
     const totalPages = Math.max(1, Math.ceil(totalRows / PAGE_SIZE));
-    const rows = db.prepare(`SELECT rowid, * FROM "${tableName}" LIMIT ?`).all(PAGE_SIZE);
+    const rows = db.prepare(`SELECT *, rowid as rowid FROM "${tableName}" LIMIT ?`).all(PAGE_SIZE);
     res.render('admin-dashboard', {
       user: { id: req.session.userId, name: req.session.userName },
       tables, activeTable: tableName, columns, rows, page: 1, totalPages, totalRows, search: '',

--- a/src/controllers/admin-controller.js
+++ b/src/controllers/admin-controller.js
@@ -1,5 +1,5 @@
 const db = require('../../database/db');
-const { buildSearchQuery } = require('../services/admin-helpers');
+const { FK_DISPLAY, getInputType, friendlyError, buildSearchQuery } = require('../services/admin-helpers');
 
 const PAGE_SIZE = 20;
 
@@ -9,13 +9,40 @@ const getAllTables = () =>
 const getColumns = (tableName) =>
   db.prepare(`PRAGMA table_info("${tableName}")`).all();
 
+const getForeignKeys = (tableName) =>
+  db.prepare(`PRAGMA foreign_key_list("${tableName}")`).all();
+
+const getForeignKeyOptions = (fkList) => {
+  const options = {};
+  fkList.forEach(fk => {
+    if (!options[fk.from]) {
+      const display = FK_DISPLAY[fk.table];
+      if (display) {
+        const [valCol, labelCol] = display;
+        const rows = db.prepare(`SELECT "${valCol}" as val, "${labelCol}" as label FROM "${fk.table}" ORDER BY 2`).all();
+        options[fk.from] = rows.map(r => ({ value: r.val, label: `${r.val} — ${r.label}` }));
+      } else {
+        const rows = db.prepare(`SELECT "${fk.to}" as val FROM "${fk.table}" ORDER BY 1`).all();
+        options[fk.from] = rows.map(r => ({ value: r.val, label: String(r.val) }));
+      }
+    }
+  });
+  return options;
+};
+
+const getInputTypes = (columns) => {
+  const types = {};
+  columns.forEach(col => { types[col.name] = getInputType(col.name); });
+  return types;
+};
+
 const showAdminDashboard = (req, res) => {
   const user = { id: req.session.userId, name: req.session.userName };
   const tables = getAllTables();
   res.render('admin-dashboard', {
     user, tables,
     activeTable: null, columns: [], rows: [], page: 1, totalPages: 1, totalRows: 0, search: '',
-    error: null, success: null,
+    fkOptions: {}, inputTypes: {}, error: null, success: null,
   });
 };
 
@@ -30,6 +57,8 @@ const showTable = (req, res) => {
   const offset = (page - 1) * PAGE_SIZE;
   const search = (req.query.search || '').trim();
   const columns = getColumns(tableName);
+  const fkOptions = getForeignKeyOptions(getForeignKeys(tableName));
+  const inputTypes = getInputTypes(columns);
 
   let totalRows, rows;
   if (search) {
@@ -45,7 +74,7 @@ const showTable = (req, res) => {
 
   res.render('admin-dashboard', {
     user, tables,
-    activeTable: tableName, columns, rows, page, totalPages, totalRows, search,
+    activeTable: tableName, columns, rows, page, totalPages, totalRows, search, fkOptions, inputTypes,
     error: req.query.error || null,
     success: req.query.success || null,
   });
@@ -66,13 +95,15 @@ const createRecord = (req, res) => {
     db.prepare(`INSERT INTO "${tableName}" (${fieldList}) VALUES (${placeholders})`).run(...values);
     res.redirect(`/admin/table/${tableName}?success=Record+added`);
   } catch (err) {
+    const fkOptions = getForeignKeyOptions(getForeignKeys(tableName));
+    const inputTypes = getInputTypes(columns);
     const totalRows = db.prepare(`SELECT COUNT(*) as count FROM "${tableName}"`).get().count;
     const totalPages = Math.max(1, Math.ceil(totalRows / PAGE_SIZE));
     const rows = db.prepare(`SELECT rowid, * FROM "${tableName}" LIMIT ?`).all(PAGE_SIZE);
     res.render('admin-dashboard', {
       user: { id: req.session.userId, name: req.session.userName },
       tables, activeTable: tableName, columns, rows, page: 1, totalPages, totalRows, search: '',
-      error: err.message, success: null,
+      fkOptions, inputTypes, error: friendlyError(err.message), success: null,
     });
   }
 };
@@ -97,7 +128,7 @@ const updateRecord = (req, res) => {
     db.prepare(`UPDATE "${tableName}" SET ${setClauses} WHERE rowid = ?`).run(...values);
     res.redirect(`/admin/table/${tableName}?success=Record+updated`);
   } catch (err) {
-    res.redirect(`/admin/table/${tableName}?error=${encodeURIComponent(err.message)}`);
+    res.redirect(`/admin/table/${tableName}?error=${encodeURIComponent(friendlyError(err.message))}`);
   }
 };
 
@@ -111,7 +142,7 @@ const deleteRecord = (req, res) => {
     db.prepare(`DELETE FROM "${tableName}" WHERE rowid = ?`).run(rowId);
     res.redirect(`/admin/table/${tableName}?success=Record+deleted`);
   } catch (err) {
-    res.redirect(`/admin/table/${tableName}?error=${encodeURIComponent(err.message)}`);
+    res.redirect(`/admin/table/${tableName}?error=${encodeURIComponent(friendlyError(err.message))}`);
   }
 };
 

--- a/src/services/admin-helpers.js
+++ b/src/services/admin-helpers.js
@@ -1,7 +1,34 @@
+const FK_DISPLAY = {
+  students:    ['student_number', 'name'],
+  staff:       ['staff_number', 'name'],
+  courses:     ['course_code', 'course_name'],
+  departments: ['dept_code', 'dept_name'],
+  degrees:     ['degree_code', 'degree_name'],
+};
+
+const DAY_OPTIONS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+
+const getInputType = (colName) => {
+  if (colName === 'day_of_week')                          return { type: 'select', options: DAY_OPTIONS };
+  if (colName.includes('email'))                          return { type: 'email',  options: null };
+  if (colName.includes('password'))                       return { type: 'password', options: null };
+  if (colName.endsWith('_time'))                          return { type: 'time',   options: null };
+  if (colName.endsWith('_date') || colName === 'consultation_date') return { type: 'date', options: null };
+  return { type: 'text', options: null };
+};
+
+const friendlyError = (msg) => {
+  if (msg.includes('FOREIGN KEY'))  return 'This value references a record that does not exist, or is still referenced by another record.';
+  if (msg.includes('UNIQUE'))       return 'A record with this value already exists.';
+  if (msg.includes('CHECK'))        return 'One of the values does not meet the required rules for this field.';
+  if (msg.includes('NOT NULL'))     return 'A required field was left empty.';
+  return msg;
+};
+
 const buildSearchQuery = (columns, searchTerm) => {
   const whereClauses = columns.map(c => `"${c.name}" LIKE ?`).join(' OR ');
   const params = columns.map(() => `%${searchTerm}%`);
   return { whereClauses, params };
 };
 
-module.exports = { buildSearchQuery };
+module.exports = { FK_DISPLAY, getInputType, friendlyError, buildSearchQuery };

--- a/src/views/admin-dashboard.html
+++ b/src/views/admin-dashboard.html
@@ -152,9 +152,27 @@ function formatCol(name) {
                         <small class="text-muted fw-normal">(<%= col.type %>)</small>
                         <% if (col.notnull && col.pk === 0) { %><span class="text-danger">*</span><% } %>
                       </label>
-                      <input type="text" class="form-control" name="<%= col.name %>"
-                        <% if (col.pk && col.type.toUpperCase() === 'INTEGER') { %>placeholder="Auto-assigned if blank"<% } %>
-                        <% if (col.notnull && col.pk === 0) { %>required<% } %>>
+                      <% if (fkOptions[col.name]) { %>
+                        <select class="form-select" name="<%= col.name %>" <% if (col.notnull && col.pk === 0) { %>required<% } %>>
+                          <option value="">-- Select --</option>
+                          <% fkOptions[col.name].forEach(function(opt) { %>
+                            <option value="<%= opt.value %>"><%= opt.label %></option>
+                          <% }); %>
+                        </select>
+                      <% } else if (inputTypes[col.name] && inputTypes[col.name].type === 'select') { %>
+                        <select class="form-select" name="<%= col.name %>" <% if (col.notnull && col.pk === 0) { %>required<% } %>>
+                          <option value="">-- Select --</option>
+                          <% inputTypes[col.name].options.forEach(function(opt) { %>
+                            <option value="<%= opt %>"><%= opt %></option>
+                          <% }); %>
+                        </select>
+                      <% } else { %>
+                        <input
+                          type="<%= (inputTypes[col.name] && inputTypes[col.name].type) || 'text' %>"
+                          class="form-control" name="<%= col.name %>"
+                          <% if (col.pk && col.type.toUpperCase() === 'INTEGER') { %>placeholder="Auto-assigned if blank"<% } %>
+                          <% if (col.notnull && col.pk === 0) { %>required<% } %>>
+                      <% } %>
                     </div>
                   <% }); %>
                 </div>
@@ -226,6 +244,8 @@ function formatCol(name) {
   <script>
     const columns = <%- JSON.stringify(columns) %>;
     const activeTable = <%- JSON.stringify(activeTable) %>;
+    const fkOptions = <%- JSON.stringify(fkOptions) %>;
+    const inputTypes = <%- JSON.stringify(inputTypes) %>;
 
     function formatCol(name) {
       const map = { id: 'ID', of: 'of' };
@@ -234,35 +254,71 @@ function formatCol(name) {
         .join(' ');
     }
 
+    function buildField(col, currentValue) {
+      const isReadOnly = col.pk > 0;
+      const div = document.createElement('div');
+      div.className = 'mb-3';
+
+      const label = document.createElement('label');
+      label.className = 'form-label fw-semibold';
+      label.textContent = formatCol(col.name) + ' (' + col.type + ')';
+      if (isReadOnly) {
+        const badge = document.createElement('span');
+        badge.className = 'badge bg-secondary ms-1 fw-normal';
+        badge.textContent = 'PK';
+        label.appendChild(badge);
+      }
+      div.appendChild(label);
+
+      if (!isReadOnly && fkOptions[col.name]) {
+        const select = document.createElement('select');
+        select.className = 'form-select';
+        select.name = col.name;
+        const blank = document.createElement('option');
+        blank.value = '';
+        blank.textContent = '-- Select --';
+        select.appendChild(blank);
+        fkOptions[col.name].forEach(opt => {
+          const o = document.createElement('option');
+          o.value = opt.value;
+          o.textContent = opt.label;
+          if (String(opt.value) === String(currentValue)) o.selected = true;
+          select.appendChild(o);
+        });
+        div.appendChild(select);
+      } else if (!isReadOnly && inputTypes[col.name] && inputTypes[col.name].type === 'select') {
+        const select = document.createElement('select');
+        select.className = 'form-select';
+        select.name = col.name;
+        const blank = document.createElement('option');
+        blank.value = '';
+        blank.textContent = '-- Select --';
+        select.appendChild(blank);
+        inputTypes[col.name].options.forEach(opt => {
+          const o = document.createElement('option');
+          o.value = opt;
+          o.textContent = opt;
+          if (opt === currentValue) o.selected = true;
+          select.appendChild(o);
+        });
+        div.appendChild(select);
+      } else {
+        const input = document.createElement('input');
+        input.type = (!isReadOnly && inputTypes[col.name]) ? inputTypes[col.name].type : 'text';
+        input.className = 'form-control';
+        input.name = col.name;
+        input.value = currentValue != null ? currentValue : '';
+        if (isReadOnly) input.readOnly = true;
+        div.appendChild(input);
+      }
+
+      return div;
+    }
+
     function openEdit(row, rowid) {
       const body = document.getElementById('editModalBody');
       body.innerHTML = '';
-      columns.forEach(col => {
-        const isReadOnly = col.pk > 0;
-        const div = document.createElement('div');
-        div.className = 'mb-3';
-
-        const label = document.createElement('label');
-        label.className = 'form-label fw-semibold';
-        label.textContent = formatCol(col.name) + ' (' + col.type + ')';
-        if (isReadOnly) {
-          const badge = document.createElement('span');
-          badge.className = 'badge bg-secondary ms-1 fw-normal';
-          badge.textContent = 'PK';
-          label.appendChild(badge);
-        }
-
-        const input = document.createElement('input');
-        input.type = 'text';
-        input.className = 'form-control';
-        input.name = col.name;
-        input.value = row[col.name] != null ? row[col.name] : '';
-        if (isReadOnly) input.readOnly = true;
-
-        div.appendChild(label);
-        div.appendChild(input);
-        body.appendChild(div);
-      });
+      columns.forEach(col => body.appendChild(buildField(col, row[col.name])));
       document.getElementById('editForm').action = '/admin/table/' + activeTable + '/' + rowid + '/update';
       new bootstrap.Modal(document.getElementById('editModal')).show();
     }

--- a/tests/unit/admin-controller.test.js
+++ b/tests/unit/admin-controller.test.js
@@ -30,6 +30,7 @@ const COLUMNS = [
   { cid: 1, name: 'name',     type: 'TEXT', notnull: 1, dflt_value: null, pk: 0 },
 ];
 const ROWS = [{ rowid: 1, admin_id: 'ADMIN001', name: 'System Admin' }];
+const NO_FK = [];
 
 beforeEach(() => db.prepare.mockReset());
 
@@ -54,10 +55,11 @@ describe('showAdminDashboard', () => {
 describe('showTable', () => {
   test('renders table data for a valid table name', () => {
     db.prepare
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ count: 1 }) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(ROWS) });
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })   // getAllTables
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })  // getColumns
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(NO_FK) })    // getForeignKeys
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ count: 1 }) }) // COUNT
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(ROWS) });    // SELECT rows
 
     const req = mockReq({ params: { tableName: 'admins' }, query: {} });
     const res = mockRes();
@@ -76,10 +78,11 @@ describe('showTable', () => {
 
   test('filters rows using SQL LIKE when a search term is provided', () => {
     db.prepare
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ count: 1 }) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(ROWS) });
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })   // getAllTables
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })  // getColumns
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(NO_FK) })    // getForeignKeys
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ count: 1 }) }) // COUNT with LIKE
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(ROWS) });    // SELECT with LIKE
 
     const req = mockReq({ params: { tableName: 'admins' }, query: { search: 'Admin' } });
     const res = mockRes();
@@ -109,9 +112,9 @@ describe('showTable', () => {
 describe('createRecord', () => {
   test('redirects to the table view on successful insert', () => {
     db.prepare
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })
-      .mockReturnValueOnce({ run: jest.fn() });
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })   // getAllTables
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })  // getColumns
+      .mockReturnValueOnce({ run: jest.fn() });                          // INSERT
 
     const req = mockReq({
       params: { tableName: 'admins' },
@@ -124,13 +127,14 @@ describe('createRecord', () => {
     expect(res.redirect).toHaveBeenCalledWith('/admin/table/admins?success=Record+added');
   });
 
-  test('re-renders with error message when the insert fails', () => {
+  test('re-renders with friendly error message when the insert fails', () => {
     db.prepare
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })   // getAllTables
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })  // getColumns
       .mockReturnValueOnce({ run: jest.fn().mockImplementation(() => { throw new Error('UNIQUE constraint failed'); }) })
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ count: 1 }) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(ROWS) });
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(NO_FK) })    // getForeignKeys (error path)
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ count: 1 }) }) // COUNT
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(ROWS) });    // SELECT rows
 
     const req = mockReq({
       params: { tableName: 'admins' },
@@ -141,7 +145,7 @@ describe('createRecord', () => {
     createRecord(req, res);
 
     expect(res.render).toHaveBeenCalledWith('admin-dashboard', expect.objectContaining({
-      error: 'UNIQUE constraint failed',
+      error: 'A record with this value already exists.',
       activeTable: 'admins',
     }));
   });
@@ -150,9 +154,9 @@ describe('createRecord', () => {
 describe('updateRecord', () => {
   test('redirects to the table view on successful update', () => {
     db.prepare
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })
-      .mockReturnValueOnce({ run: jest.fn() });
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })   // getAllTables
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })  // getColumns
+      .mockReturnValueOnce({ run: jest.fn() });                          // UPDATE
 
     const req = mockReq({
       params: { tableName: 'admins', rowId: '1' },
@@ -165,10 +169,10 @@ describe('updateRecord', () => {
     expect(res.redirect).toHaveBeenCalledWith('/admin/table/admins?success=Record+updated');
   });
 
-  test('redirects with error when the update fails', () => {
+  test('redirects with friendly error when the update fails', () => {
     db.prepare
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })   // getAllTables
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(COLUMNS) })  // getColumns
       .mockReturnValueOnce({ run: jest.fn().mockImplementation(() => { throw new Error('NOT NULL constraint failed'); }) });
 
     const req = mockReq({
@@ -179,15 +183,17 @@ describe('updateRecord', () => {
 
     updateRecord(req, res);
 
-    expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining('/admin/table/admins?error='));
+    expect(res.redirect).toHaveBeenCalledWith(
+      '/admin/table/admins?error=' + encodeURIComponent('A required field was left empty.')
+    );
   });
 });
 
 describe('deleteRecord', () => {
   test('redirects to the table view on successful delete', () => {
     db.prepare
-      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })
-      .mockReturnValueOnce({ run: jest.fn() });
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(TABLES) })   // getAllTables
+      .mockReturnValueOnce({ run: jest.fn() });                          // DELETE
 
     const req = mockReq({ params: { tableName: 'courses', rowId: '1' } });
     const res = mockRes();
@@ -208,7 +214,7 @@ describe('deleteRecord', () => {
     expect(res.redirect).toHaveBeenCalledWith('/admin/table/admins?error=Admin+accounts+cannot+be+deleted');
   });
 
-  test('redirects with error when a foreign key constraint prevents deletion', () => {
+  test('redirects with friendly error when a foreign key constraint prevents deletion', () => {
     db.prepare
       .mockReturnValueOnce({ all: jest.fn().mockReturnValue([{ name: 'departments' }]) })
       .mockReturnValueOnce({ run: jest.fn().mockImplementation(() => { throw new Error('FOREIGN KEY constraint failed'); }) });
@@ -218,6 +224,8 @@ describe('deleteRecord', () => {
 
     deleteRecord(req, res);
 
-    expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining('/admin/table/departments?error='));
+    expect(res.redirect).toHaveBeenCalledWith(
+      '/admin/table/departments?error=' + encodeURIComponent('This value references a record that does not exist, or is still referenced by another record.')
+    );
   });
 });

--- a/tests/unit/admin-helpers.test.js
+++ b/tests/unit/admin-helpers.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-const { buildSearchQuery } = require('../../src/services/admin-helpers');
+const { buildSearchQuery, getInputType, friendlyError } = require('../../src/services/admin-helpers');
 
 const COLUMNS = [
   { name: 'admin_id', pk: 1 },
@@ -21,5 +21,66 @@ describe('buildSearchQuery', () => {
   test('produces one param entry per column', () => {
     const { params } = buildSearchQuery(COLUMNS, 'x');
     expect(params).toHaveLength(COLUMNS.length);
+  });
+});
+
+describe('getInputType', () => {
+  test('returns select with day options for day_of_week', () => {
+    const result = getInputType('day_of_week');
+    expect(result.type).toBe('select');
+    expect(result.options).toEqual(['Mon', 'Tue', 'Wed', 'Thu', 'Fri']);
+  });
+
+  test('returns email type for columns containing "email"', () => {
+    expect(getInputType('email').type).toBe('email');
+    expect(getInputType('staff_email').type).toBe('email');
+  });
+
+  test('returns password type for columns containing "password"', () => {
+    expect(getInputType('password').type).toBe('password');
+    expect(getInputType('hashed_password').type).toBe('password');
+  });
+
+  test('returns time type for columns ending with _time', () => {
+    expect(getInputType('start_time').type).toBe('time');
+    expect(getInputType('end_time').type).toBe('time');
+  });
+
+  test('returns date type for columns ending with _date or named consultation_date', () => {
+    expect(getInputType('booking_date').type).toBe('date');
+    expect(getInputType('consultation_date').type).toBe('date');
+  });
+
+  test('returns text type for unrecognised column names', () => {
+    const result = getInputType('student_number');
+    expect(result.type).toBe('text');
+    expect(result.options).toBeNull();
+  });
+});
+
+describe('friendlyError', () => {
+  test('maps FOREIGN KEY error to a readable message', () => {
+    const msg = friendlyError('FOREIGN KEY constraint failed');
+    expect(msg).toMatch(/references a record/i);
+  });
+
+  test('maps UNIQUE error to a readable message', () => {
+    const msg = friendlyError('UNIQUE constraint failed: students.student_number');
+    expect(msg).toMatch(/already exists/i);
+  });
+
+  test('maps CHECK error to a readable message', () => {
+    const msg = friendlyError('CHECK constraint failed: lecturer_availability');
+    expect(msg).toMatch(/required rules/i);
+  });
+
+  test('maps NOT NULL error to a readable message', () => {
+    const msg = friendlyError('NOT NULL constraint failed: staff.name');
+    expect(msg).toMatch(/required field/i);
+  });
+
+  test('returns the original message when no pattern matches', () => {
+    const raw = 'some unexpected database error';
+    expect(friendlyError(raw)).toBe(raw);
   });
 });


### PR DESCRIPTION

Closes #74
Closes #76 
Closes #82 

## What Was Changed

### FK-Aware Dropdowns

- Foreign key columns in the Add and Edit modals now render as dropdowns instead of free-text inputs.
- Options are fetched from the referenced table.
- Dropdown values are displayed with human-readable labels.
- A `FK_DISPLAY` config maps each table to its value and label columns.

### Smart Input Types

- Column names are now used to infer the correct HTML input type.
- Email columns render with `type="email"`.
- Password columns render with `type="password"`.
- Time columns render with `type="time"`.
- Date columns render with `type="date"`.
- `day_of_week` renders as a select dropdown with Monday to Friday options.
- This applies to both the Add and Edit modals.

### Friendly Constraint Error Messages

- SQLite constraint errors shown to the admin are now translated into plain English.
- `FOREIGN KEY`, `UNIQUE`, `CHECK`, and `NOT NULL` violations each produce a specific readable message.
- Raw SQLite error strings are no longer shown directly to non-technical admin users.

### Rowid Fix for `INTEGER PRIMARY KEY` Tables

- Edit and delete were broken for tables like `students` and `lecturer_availability`.
- This happened because `SELECT rowid, *` can lose the `rowid` key when a table uses `INTEGER PRIMARY KEY`, since that primary key aliases `rowid`.
- The query was changed to:

```sql
SELECT *, rowid AS rowid