### PR TITLE
Email verification

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const express = require('express')
 const session = require('express-session')
 const path = require('path')

--- a/database/createSchema.sql
+++ b/database/createSchema.sql
@@ -15,6 +15,7 @@ DROP TABLE IF EXISTS degrees;
 DROP TABLE IF EXISTS departments;
 DROP TABLE IF EXISTS lecturer_availability;
 DROP TABLE IF EXISTS admins;
+DROP TABLE IF EXISTS failed_login_log;
 DROP TABLE IF EXISTS admin_audit_log;
 DROP TABLE IF EXISTS affected_records;
 DROP TABLE IF EXISTS activity_log;
@@ -46,7 +47,9 @@ CREATE TABLE students (
   email_verified     INTEGER NOT NULL DEFAULT 0,
   verification_token TEXT,
   token_expiry       TEXT,
-  resend_count       INTEGER NOT NULL DEFAULT 0
+  resend_count       INTEGER NOT NULL DEFAULT 0,
+  failed_attempts    INTEGER NOT NULL DEFAULT 0,
+  login_pin          TEXT
 );
 
 CREATE TABLE courses (
@@ -74,7 +77,9 @@ CREATE TABLE staff (
   email_verified     INTEGER NOT NULL DEFAULT 0,
   verification_token TEXT,
   token_expiry       TEXT,
-  resend_count       INTEGER NOT NULL DEFAULT 0
+  resend_count       INTEGER NOT NULL DEFAULT 0,
+  failed_attempts    INTEGER NOT NULL DEFAULT 0,
+  login_pin          TEXT
 );
 
 CREATE TABLE staff_courses (
@@ -159,6 +164,13 @@ CREATE INDEX IF NOT EXISTS idx_admin_audit_log_admin
 
 CREATE INDEX IF NOT EXISTS idx_admin_audit_log_table_row
   ON admin_audit_log(table_name, row_id);
+
+CREATE TABLE failed_login_log (
+  log_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+  identifier   TEXT NOT NULL,
+  attempted_at TEXT NOT NULL DEFAULT (datetime('now')),
+  pin_triggered INTEGER NOT NULL DEFAULT 0
+);
 
 CREATE TABLE actions (
     action_id INT PRIMARY KEY,

--- a/database/createSchema.sql
+++ b/database/createSchema.sql
@@ -38,11 +38,15 @@ CREATE TABLE degrees (
 );
 
 CREATE TABLE students (
-  student_number  INTEGER PRIMARY KEY,
-  name            TEXT NOT NULL,
-  email           TEXT NOT NULL UNIQUE,
-  password        TEXT NOT NULL,
-  degree_code     TEXT NOT NULL REFERENCES degrees(degree_code)
+  student_number     INTEGER PRIMARY KEY,
+  name               TEXT NOT NULL,
+  email              TEXT NOT NULL UNIQUE,
+  password           TEXT NOT NULL,
+  degree_code        TEXT NOT NULL REFERENCES degrees(degree_code),
+  email_verified     INTEGER NOT NULL DEFAULT 0,
+  verification_token TEXT,
+  token_expiry       TEXT,
+  resend_count       INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE courses (
@@ -61,12 +65,16 @@ CREATE TABLE enrollments (
 );
 
 CREATE TABLE staff (
-  staff_number TEXT PRIMARY KEY,
-  name         TEXT NOT NULL,
-  email        TEXT UNIQUE NOT NULL,
-  department   TEXT,
-  dept_code    TEXT REFERENCES departments(dept_code),
-  password     TEXT
+  staff_number       TEXT PRIMARY KEY,
+  name               TEXT NOT NULL,
+  email              TEXT UNIQUE NOT NULL,
+  department         TEXT,
+  dept_code          TEXT REFERENCES departments(dept_code),
+  password           TEXT,
+  email_verified     INTEGER NOT NULL DEFAULT 0,
+  verification_token TEXT,
+  token_expiry       TEXT,
+  resend_count       INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE staff_courses (

--- a/database/seedDemoData.sql
+++ b/database/seedDemoData.sql
@@ -12,18 +12,18 @@
 -- ─── Demo Lecturers ──────────────────────────────────────────────────────────
 -- EIE (2 new + 2 existing: Clark Kent A000356, Lois Lane A000357)
 -- MIA, MINE, ARPL, CHMT, CIVN, FEBE (1-2 new each)
-INSERT OR IGNORE INTO staff (staff_number, name, email, department, dept_code, password) VALUES
-  ('A000358', 'Bruce Wayne',      'bruce.wayne@wits.ac.za',      'EIE',  'EIE',  'pass'),
-  ('A000359', 'Diana Prince',     'diana.prince@wits.ac.za',     'EIE',  'EIE',  'pass'),
-  ('A000360', 'Tony Stark',       'tony.stark@wits.ac.za',       'MIA',  'MIA',  'pass'),
-  ('A000361', 'Natasha Romanoff', 'natasha.romanoff@wits.ac.za', 'CIVN', 'CIVN', 'pass'),
-  ('A000362', 'Steve Rogers',     'steve.rogers@wits.ac.za',     'CHMT', 'CHMT', 'pass'),
-  ('A000363', 'Peter Parker',     'peter.parker@wits.ac.za',     'MIA',  'MIA',  'pass'),
-  ('A000364', 'Thor Odinson',     'thor.odinson@wits.ac.za',     'MINE', 'MINE', 'pass'),
-  ('A000365', 'Wanda Maximoff',   'wanda.maximoff@wits.ac.za',   'ARPL', 'ARPL', 'pass'),
-  ('A000366', 'Nick Fury',        'nick.fury@wits.ac.za',        'CHMT', 'CHMT', 'pass'),
-  ('A000367', 'Sam Wilson',       'sam.wilson@wits.ac.za',       'CIVN', 'CIVN', 'pass'),
-  ('A000368', 'Maria Hill',       'maria.hill@wits.ac.za',       'FEBE', 'FEBE', 'pass');
+INSERT OR IGNORE INTO staff (staff_number, name, email, department, dept_code, password, email_verified) VALUES
+  ('A000358', 'Bruce Wayne',      'bruce.wayne@wits.ac.za',      'EIE',  'EIE',  'pass', 1),
+  ('A000359', 'Diana Prince',     'diana.prince@wits.ac.za',     'EIE',  'EIE',  'pass', 1),
+  ('A000360', 'Tony Stark',       'tony.stark@wits.ac.za',       'MIA',  'MIA',  'pass', 1),
+  ('A000361', 'Natasha Romanoff', 'natasha.romanoff@wits.ac.za', 'CIVN', 'CIVN', 'pass', 1),
+  ('A000362', 'Steve Rogers',     'steve.rogers@wits.ac.za',     'CHMT', 'CHMT', 'pass', 1),
+  ('A000363', 'Peter Parker',     'peter.parker@wits.ac.za',     'MIA',  'MIA',  'pass', 1),
+  ('A000364', 'Thor Odinson',     'thor.odinson@wits.ac.za',     'MINE', 'MINE', 'pass', 1),
+  ('A000365', 'Wanda Maximoff',   'wanda.maximoff@wits.ac.za',   'ARPL', 'ARPL', 'pass', 1),
+  ('A000366', 'Nick Fury',        'nick.fury@wits.ac.za',        'CHMT', 'CHMT', 'pass', 1),
+  ('A000367', 'Sam Wilson',       'sam.wilson@wits.ac.za',       'CIVN', 'CIVN', 'pass', 1),
+  ('A000368', 'Maria Hill',       'maria.hill@wits.ac.za',       'FEBE', 'FEBE', 'pass', 1);
 
 -- ─── Staff Course Assignments ─────────────────────────────────────────────────
 -- Every course in every dept is assigned to at least one lecturer.
@@ -265,12 +265,12 @@ INSERT OR IGNORE INTO lecturer_availability (availability_id, staff_number, day_
   (72, 'A000368', 'Fri', '10:00', '11:00', 60, 6, 'Lecture Hall B');
 
 -- ─── Demo Students ───────────────────────────────────────────────────────────
-INSERT OR IGNORE INTO students (student_number, name, email, password, degree_code) VALUES
-  (2345678, 'Thabo Nkosi',    'thabo.nkosi@students.wits.ac.za',    'pass', 'BSCENGELEC'),
-  (3456789, 'Priya Patel',    'priya.patel@students.wits.ac.za',    'pass', 'BSCENGINFO'),
-  (4567890, 'James Okafor',   'james.okafor@students.wits.ac.za',   'pass', 'BSCENGMECH'),
-  (5678901, 'Lerato Dlamini', 'lerato.dlamini@students.wits.ac.za', 'pass', 'BSCENGINFO'),
-  (6789012, 'Chen Wei',       'chen.wei@students.wits.ac.za',       'pass', 'BSCENGELEC');
+INSERT OR IGNORE INTO students (student_number, name, email, password, degree_code, email_verified) VALUES
+  (2345678, 'Thabo Nkosi',    'thabo.nkosi@students.wits.ac.za',    'pass', 'BSCENGELEC', 1),
+  (3456789, 'Priya Patel',    'priya.patel@students.wits.ac.za',    'pass', 'BSCENGINFO', 1),
+  (4567890, 'James Okafor',   'james.okafor@students.wits.ac.za',   'pass', 'BSCENGMECH', 1),
+  (5678901, 'Lerato Dlamini', 'lerato.dlamini@students.wits.ac.za', 'pass', 'BSCENGINFO', 1),
+  (6789012, 'Chen Wei',       'chen.wei@students.wits.ac.za',       'pass', 'BSCENGELEC', 1);
 
 -- ─── Student Enrollments ─────────────────────────────────────────────────────
 -- Matched to lecturers' staff_courses so each student can see the correct availability

--- a/database/seedVitalInfo.sql
+++ b/database/seedVitalInfo.sql
@@ -284,9 +284,9 @@ INSERT OR IGNORE INTO courses (course_code, course_name, year_level, dept_code) 
   ('PHYS1034', 'Applied Physics I',                          1, 'FEBE');
 
 -- ─── Staff ───────────────────────────────────────────────────────────────────
-INSERT OR IGNORE INTO staff (staff_number, name, email, department, dept_code, password) VALUES
-  ('A000356', 'Clark Kent', 'clark.kent@wits.ac.za', 'EIE', 'EIE', 'pass'),
-  ('A000357', 'Lois Lane',  'lois.lane@wits.ac.za',  'EIE', 'EIE', 'pass');
+INSERT OR IGNORE INTO staff (staff_number, name, email, department, dept_code, password, email_verified) VALUES
+  ('A000356', 'Clark Kent', 'clark.kent@wits.ac.za', 'EIE', 'EIE', 'pass', 1),
+  ('A000357', 'Lois Lane',  'lois.lane@wits.ac.za',  'EIE', 'EIE', 'pass', 1);
 
 -- Staff data
 INSERT OR IGNORE INTO staff (staff_number, name, email, department, dept_code, password) VALUES
@@ -300,8 +300,8 @@ INSERT OR IGNORE INTO staff_courses (staff_number, course_code) VALUES
   ('A000357', 'ELEN4010');
 
 -- ─── Test student ─────────────────────────────────────────────────────────────
-INSERT OR IGNORE INTO students (student_number, name, email, password, degree_code) VALUES
-  (1234567, 'Aditya Raghunandan', 'aditya@students.wits.ac.za', 'pass', 'BSCENGINFO');
+INSERT OR IGNORE INTO students (student_number, name, email, password, degree_code, email_verified) VALUES
+  (1234567, 'Aditya Raghunandan', 'aditya@students.wits.ac.za', 'pass', 'BSCENGINFO', 1);
 
 INSERT OR IGNORE INTO enrollments (student_number, course_code) VALUES
   (1234567, 'ELEN4010'),

--- a/database/seedVitalInfo.sql
+++ b/database/seedVitalInfo.sql
@@ -301,7 +301,7 @@ INSERT OR IGNORE INTO staff_courses (staff_number, course_code) VALUES
 
 -- ─── Test student ─────────────────────────────────────────────────────────────
 INSERT OR IGNORE INTO students (student_number, name, email, password, degree_code, email_verified) VALUES
-  (1234567, 'Aditya Raghunandan', 'aditya@students.wits.ac.za', 'pass', 'BSCENGINFO', 1);
+  (1234567, 'Aditya Raghunandan', '2434427@students.wits.ac.za', 'pass', 'BSCENGINFO', 1);
 
 INSERT OR IGNORE INTO enrollments (student_number, course_code) VALUES
   (1234567, 'ELEN4010'),

--- a/documentation/ADR's/ADR-012-Security.md
+++ b/documentation/ADR's/ADR-012-Security.md
@@ -41,3 +41,26 @@ This message is returned regardless of whether the identifier was not found or t
 ---
 
 <!-- Append new decisions below this line using the same structure -->
+
+## Decision 2 — Email Verification Token Storage (2026-05-16)
+
+**Related to:** Issue #50 (parent), Story #109
+
+### Context
+
+Email verification requires generating a one-time code and storing it temporarily against the user's account until they confirm their inbox. A naive implementation would store the raw 6-digit code in the database. If the database were exposed, an attacker could read unverified tokens and activate arbitrary accounts.
+
+### Decision
+
+The verification code is never stored in plaintext. On generation, the code is hashed with SHA-256 and only the hex digest is persisted in `verification_token`. On submission, the user's input is hashed identically and the digests are compared. The raw code exists only in memory during generation and in the email body in transit.
+
+A 30-minute expiry (`token_expiry`) is enforced server-side. After successful verification, `verification_token` and `token_expiry` are set to NULL. Resend attempts are capped at 3 per account (`resend_count`) to limit code-farming.
+
+The post-password-check placement of the `email_verified` guard preserves the generic error message policy from Decision 1 — an unverified account is only reachable after a correct password, so no account existence information is leaked.
+
+### Consequences
+
+- Token exposure from a database leak does not allow an attacker to verify accounts — the hash is useless without the original code.
+- Expiry limits the window of a stolen code.
+- Resend cap prevents abuse of the email sending endpoint.
+- Accepted trade-off: SHA-256 is not a password hashing algorithm (no salt, fast to compute), but for a short-lived 6-digit code this is acceptable — the code's entropy is the binding constraint, not the hash strength.

--- a/documentation/ADR's/ADR-012-Security.md
+++ b/documentation/ADR's/ADR-012-Security.md
@@ -9,34 +9,29 @@ New entries are appended as security-relevant choices arise.
 
 ---
 
-## Decision 1 — Generic Login Error Message (2026-05-15)
+## Decision 1 — Login Error Messages (2026-05-15, revised 2026-05-16)
 
 **Related to:** Issue #62
 
 ### Context
 
-Story #62 specified distinct error messages for login failures: "No account found with this email" vs "Incorrect password". During implementation review this was identified as a **user enumeration vulnerability**.
+Story #62 originally specified distinct error messages for login failures ("No account found" vs "Incorrect password"). During initial implementation review this was flagged as a potential user enumeration risk. The first implementation used a generic message for all failures.
 
-Returning different messages for "account not found" vs "wrong password" allows an attacker to silently determine whether any given student or staff number is registered — no successful authentication required. This is covered by the OWASP Authentication Cheat Sheet: *"Do not tell the user which part of the authentication data was incorrect."*
-
-Specific risks for this application:
-- **Student/staff number enumeration:** Wits student numbers (7-digit integers) and staff numbers (`A######`) follow predictable formats. An automated script could probe sequential values and build a confirmed list of registered users.
-- **Credential stuffing amplification:** Knowing which IDs exist lets an attacker focus brute-force attempts only on confirmed accounts.
-- **Privacy leak:** Confirming a student number is registered reveals that person uses this system, which may not be intended to be public.
+Following user research and team review, it was found that generic errors caused significant confusion for legitimate users — particularly students who mistype their student number and receive no guidance on which field is wrong. The UX cost was judged to outweigh the security benefit in this context, where student and staff numbers are not secret (they appear on ID cards and are shared openly within the university).
 
 ### Decision
 
-The login endpoint returns a single generic message for all authentication failures:
+The login endpoint returns specific messages distinguishing "account not found" from "incorrect password", prioritising user clarity and reducing failed legitimate logins. This is acceptable given that:
 
-> **"Invalid username or password."**
-
-This message is returned regardless of whether the identifier was not found or the password was incorrect. All other acceptance criteria from story #62 are satisfied: empty fields are caught by HTML5 `required` attributes, errors display immediately inline, no sensitive data is revealed, and the user stays on the login page.
+- Wits student numbers (7-digit integers) and staff numbers (`A######`) are semi-public within the university context — they appear on ID cards and are routinely shared.
+- The information leaked ("this number is registered") is low-sensitivity in an academic setting.
+- The compensating control in Decision 3 (failed-attempt lockout with one-time PIN) directly addresses the brute-force risk that enumeration would otherwise amplify.
 
 ### Consequences
 
-- User enumeration is prevented; attackers cannot distinguish a missing account from a wrong password.
-- Credential stuffing is harder without a way to confirm valid IDs.
-- Legitimate users who mistype their ID cannot distinguish it from a wrong password — accepted trade-off standard to all secure login systems.
+- Legitimate users get actionable feedback when they mistype their ID vs their password.
+- Account existence can technically be confirmed by probing — mitigated by the rate-limiting in Decision 3.
+- This is a deliberate, documented trade-off, not an oversight.
 
 ---
 
@@ -64,3 +59,36 @@ The post-password-check placement of the `email_verified` guard preserves the ge
 - Expiry limits the window of a stolen code.
 - Resend cap prevents abuse of the email sending endpoint.
 - Accepted trade-off: SHA-256 is not a password hashing algorithm (no salt, fast to compute), but for a short-lived 6-digit code this is acceptable — the code's entropy is the binding constraint, not the hash strength.
+
+---
+
+<!-- Append new decisions below this line using the same structure -->
+
+## Decision 3 — Failed Login Lockout with One-Time PIN (2026-05-16)
+
+**Related to:** Decision 1 (compensating control for specific error messages)
+
+### Context
+
+With specific error messages now returned on login failure (Decision 1 revision), an attacker who confirms a valid account ID could attempt sustained brute-force attacks against that account's password. A compensating control is needed to rate-limit repeated failures against confirmed accounts.
+
+### Decision
+
+After 4 consecutive failed password attempts on a valid account:
+
+1. The server generates a cryptographically random 6-digit PIN, hashes it with SHA-256, and stores the hash in `login_pin` on the user's row.
+2. A security alert email is sent to the account's registered email address containing the raw PIN and a warning about the failed attempts.
+3. The event is logged to `failed_login_log` with `pin_triggered = 1` for admin visibility.
+4. On the next successful password entry, the user is redirected to `/login/pin` where they must enter the PIN before their session is established.
+5. Correct PIN entry clears `login_pin` and resets `failed_attempts` to 0.
+
+Each login failure (whether or not it triggers the lockout) is recorded in `failed_login_log`, giving administrators a real-time view of attack attempts under the Security → Failed Logins panel in the admin dashboard.
+
+The PIN is stored hashed (SHA-256) for the same reason as verification tokens in Decision 2 — database exposure does not reveal the active PIN.
+
+### Consequences
+
+- Sustained brute-force attacks against a known account are blocked after 4 attempts; the attacker cannot proceed without also compromising the target's email inbox.
+- Legitimate users who trigger the lockout (e.g., forgotten password) receive a clear email explaining what happened and how to regain access.
+- Administrators see all failed attempts and lockout events without needing to inspect raw logs.
+- Accepted trade-off: the lockout does not apply to admin accounts (which use a separate login path) and does not impose a time-based cooldown — once the PIN is issued, the account is unlocked as soon as the correct PIN is entered regardless of time elapsed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.9.0",
+        "dotenv": "^17.4.2",
         "ejs": "^5.0.2",
         "express": "^5.2.1",
-        "express-session": "^1.19.0"
+        "express-session": "^1.19.0",
+        "nodemailer": "^8.0.7"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -2383,6 +2385,18 @@
         "wrappy": "1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4342,6 +4356,15 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
   "dependencies": {
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.9.0",
+    "dotenv": "^17.4.2",
     "ejs": "^5.0.2",
     "express": "^5.2.1",
-    "express-session": "^1.19.0"
+    "express-session": "^1.19.0",
+    "nodemailer": "^8.0.7"
   }
 }

--- a/src/controllers/admin-controller.js
+++ b/src/controllers/admin-controller.js
@@ -6,7 +6,7 @@ const { logAdminAudit } = require('../services/admin-audit-service')
 
 const PAGE_SIZE = 20
 // tables the admin UI can view but not modify
-const READ_ONLY_TABLES = ['admin_audit_log']
+const READ_ONLY_TABLES = ['admin_audit_log', 'failed_login_log']
 
 const getAllTables = () =>
   db.prepare('SELECT name FROM sqlite_master WHERE type=\'table\' ORDER BY name').all().map(r => r.name)

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -17,6 +17,12 @@ const login = async (req, res) => {
 
   const staff = db.prepare('SELECT * FROM staff WHERE staff_number = ?').get(staffStudentNumber)
   if (staff && staff.password === password) {
+    if (!staff.email_verified) {
+      return res.render('login', {
+        error: 'Your email address has not been verified. Please check your inbox.',
+        success: null,
+      })
+    }
     req.session.userId = staff.staff_number
     req.session.userName = staff.name
     req.session.userRole = 'lecturer'
@@ -27,11 +33,16 @@ const login = async (req, res) => {
 
   const student = db.prepare('SELECT * FROM students WHERE student_number = ?').get(staffStudentNumber)
   if (student && student.password === password) {
+    if (!student.email_verified) {
+      return res.render('login', {
+        error: 'Your email address has not been verified. Please check your inbox.',
+        success: null,
+      })
+    }
     req.session.userId = student.student_number
     req.session.userName = student.name
     req.session.userRole = 'student'
     req.session.showWelcome = true
-
     await logActivity(student.student_number, ActionTypes.USER_LOGIN, [])
     return res.redirect('/student/dashboard?welcome=1')
   }

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -1,6 +1,8 @@
+const crypto = require('crypto')
 const db = require('../../database/db')
 const { logActivity } = require('../services/logging-service')
 const ActionTypes = require('../services/action-types')
+const { sendLoginWarningEmail } = require('../services/email-service')
 
 const showLogin = (req, res) => {
   if (req.session && req.session.userId) {
@@ -12,39 +14,85 @@ const showLogin = (req, res) => {
   return res.render('login', { error: null, success: req.query.success || null })
 }
 
+const _recordFailedAttempt = async (userId, table, email) => {
+  const idCol = table === 'staff' ? 'staff_number' : 'student_number'
+
+  db.prepare(`UPDATE ${table} SET failed_attempts = failed_attempts + 1 WHERE ${idCol} = ?`).run(userId)
+  const row = db.prepare(`SELECT failed_attempts FROM ${table} WHERE ${idCol} = ?`).get(userId)
+  const attempts = row ? row.failed_attempts : 1
+
+  const pinTriggered = attempts === 4 ? 1 : 0
+  db.prepare('INSERT INTO failed_login_log (identifier, pin_triggered) VALUES (?, ?)').run(String(userId), pinTriggered)
+
+  if (attempts === 4) {
+    const pin = String(Math.floor(100000 + Math.random() * 900000))
+    const pinHash = crypto.createHash('sha256').update(pin).digest('hex')
+    db.prepare(`UPDATE ${table} SET login_pin = ? WHERE ${idCol} = ?`).run(pinHash, userId)
+    try {
+      await sendLoginWarningEmail(email, pin)
+    } catch (err) {
+      console.error('Login warning email failed to send:', err)
+    }
+  }
+
+  await logActivity(String(userId), ActionTypes.AUTH_FAILED_LOGIN, [])
+}
+
 const login = async (req, res) => {
   const { staffStudentNumber, password } = req.body
 
   const staff = db.prepare('SELECT * FROM staff WHERE staff_number = ?').get(staffStudentNumber)
-  if (staff && staff.password === password) {
-    if (!staff.email_verified) {
-      return res.render('login', {
-        error: 'Your email address has not been verified. Please check your inbox.',
-        success: null,
-      })
+  if (staff) {
+    if (staff.password === password) {
+      if (!staff.email_verified) {
+        return res.render('login', {
+          error: 'Your email address has not been verified. Please check your inbox.',
+          success: null,
+        })
+      }
+      if (staff.login_pin) {
+        req.session.pendingUserId = staff.staff_number
+        req.session.pendingUserRole = 'lecturer'
+        req.session.pendingUserName = staff.name
+        return res.redirect('/login/pin')
+      }
+      db.prepare('UPDATE staff SET failed_attempts = 0 WHERE staff_number = ?').run(staff.staff_number)
+      req.session.userId = staff.staff_number
+      req.session.userName = staff.name
+      req.session.userRole = 'lecturer'
+      req.session.showWelcome = true
+      await logActivity(staff.staff_number, ActionTypes.USER_LOGIN, [])
+      return res.redirect('/lecturer/dashboard?welcome=1')
     }
-    req.session.userId = staff.staff_number
-    req.session.userName = staff.name
-    req.session.userRole = 'lecturer'
-    req.session.showWelcome = true
-    await logActivity(staff.staff_number, ActionTypes.USER_LOGIN, [])
-    return res.redirect('/lecturer/dashboard?welcome=1')
+    await _recordFailedAttempt(staff.staff_number, 'staff', staff.email)
+    return res.render('login', { error: 'Invalid username or password.', success: null })
   }
 
   const student = db.prepare('SELECT * FROM students WHERE student_number = ?').get(staffStudentNumber)
-  if (student && student.password === password) {
-    if (!student.email_verified) {
-      return res.render('login', {
-        error: 'Your email address has not been verified. Please check your inbox.',
-        success: null,
-      })
+  if (student) {
+    if (student.password === password) {
+      if (!student.email_verified) {
+        return res.render('login', {
+          error: 'Your email address has not been verified. Please check your inbox.',
+          success: null,
+        })
+      }
+      if (student.login_pin) {
+        req.session.pendingUserId = student.student_number
+        req.session.pendingUserRole = 'student'
+        req.session.pendingUserName = student.name
+        return res.redirect('/login/pin')
+      }
+      db.prepare('UPDATE students SET failed_attempts = 0 WHERE student_number = ?').run(student.student_number)
+      req.session.userId = student.student_number
+      req.session.userName = student.name
+      req.session.userRole = 'student'
+      req.session.showWelcome = true
+      await logActivity(student.student_number, ActionTypes.USER_LOGIN, [])
+      return res.redirect('/student/dashboard?welcome=1')
     }
-    req.session.userId = student.student_number
-    req.session.userName = student.name
-    req.session.userRole = 'student'
-    req.session.showWelcome = true
-    await logActivity(student.student_number, ActionTypes.USER_LOGIN, [])
-    return res.redirect('/student/dashboard?welcome=1')
+    await _recordFailedAttempt(student.student_number, 'students', student.email)
+    return res.render('login', { error: 'Invalid username or password.', success: null })
   }
 
   let admin = null
@@ -56,8 +104,53 @@ const login = async (req, res) => {
     await logActivity(admin.admin_id, ActionTypes.USER_LOGIN, [])
     return res.redirect('/admin/dashboard')
   }
+
   await logActivity(staffStudentNumber || 'UNKNOWN', ActionTypes.AUTH_FAILED_LOGIN, [])
   return res.render('login', { error: 'Invalid username or password.', success: null })
+}
+
+const showLoginPin = (req, res) => {
+  if (!req.session.pendingUserId) return res.redirect('/login')
+  return res.render('login-pin', { error: null })
+}
+
+const verifyLoginPin = async (req, res) => {
+  if (!req.session.pendingUserId) return res.redirect('/login')
+
+  const { pin } = req.body
+  const userId = req.session.pendingUserId
+  const role = req.session.pendingUserRole
+  const name = req.session.pendingUserName
+
+  const table = role === 'lecturer' ? 'staff' : 'students'
+  const idCol = role === 'lecturer' ? 'staff_number' : 'student_number'
+
+  const user = db.prepare(`SELECT login_pin FROM ${table} WHERE ${idCol} = ?`).get(userId)
+
+  if (!user || !user.login_pin) {
+    delete req.session.pendingUserId
+    return res.redirect('/login')
+  }
+
+  const pinHash = crypto.createHash('sha256').update(pin).digest('hex')
+  if (pinHash !== user.login_pin) {
+    return res.render('login-pin', { error: 'Incorrect PIN. Check your security alert email and try again.' })
+  }
+
+  db.prepare(`UPDATE ${table} SET login_pin = NULL, failed_attempts = 0 WHERE ${idCol} = ?`).run(userId)
+
+  delete req.session.pendingUserId
+  delete req.session.pendingUserRole
+  delete req.session.pendingUserName
+  req.session.userId = userId
+  req.session.userName = name
+  req.session.userRole = role
+  req.session.showWelcome = true
+
+  await logActivity(String(userId), ActionTypes.USER_LOGIN, [])
+
+  const dashUrl = role === 'lecturer' ? '/lecturer/dashboard?welcome=1' : '/student/dashboard?welcome=1'
+  return res.redirect(dashUrl)
 }
 
 const logout = async (req, res) => {
@@ -67,4 +160,4 @@ const logout = async (req, res) => {
   })
 }
 
-module.exports = { showLogin, login, logout }
+module.exports = { showLogin, login, logout, showLoginPin, verifyLoginPin }

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -134,7 +134,31 @@ const login = async (req, res) => {
 
 const showLoginPin = (req, res) => {
   if (!req.session.pendingUserId) return res.redirect('/login')
-  return res.render('login-pin', { error: null })
+  return res.render('login-pin', { error: null, message: null })
+}
+
+const resendLoginPin = async (req, res) => {
+  if (!req.session.pendingUserId) return res.redirect('/login')
+
+  const userId = req.session.pendingUserId
+  const role = req.session.pendingUserRole
+  const table = role === 'lecturer' ? 'staff' : 'students'
+  const idCol = role === 'lecturer' ? 'staff_number' : 'student_number'
+
+  const user = db.prepare(`SELECT email FROM ${table} WHERE ${idCol} = ?`).get(userId)
+  if (!user) return res.redirect('/login')
+
+  const pin = String(Math.floor(100000 + Math.random() * 900000))
+  const pinHash = crypto.createHash('sha256').update(pin).digest('hex')
+  db.prepare(`UPDATE ${table} SET login_pin = ? WHERE ${idCol} = ?`).run(pinHash, userId)
+
+  try {
+    await sendLoginWarningEmail(user.email, pin)
+    return res.render('login-pin', { error: null, message: 'A new PIN has been sent to your email.' })
+  } catch (err) {
+    console.error('Resend PIN email failed:', err)
+    return res.render('login-pin', { error: 'Failed to resend PIN. Please try again.', message: null })
+  }
 }
 
 const verifyLoginPin = async (req, res) => {
@@ -157,7 +181,7 @@ const verifyLoginPin = async (req, res) => {
 
   const pinHash = crypto.createHash('sha256').update(pin).digest('hex')
   if (pinHash !== user.login_pin) {
-    return res.render('login-pin', { error: 'Incorrect PIN. Check your security alert email and try again.' })
+    return res.render('login-pin', { error: 'Incorrect PIN. Check your security alert email and try again.', message: null })
   }
 
   db.prepare(`UPDATE ${table} SET login_pin = NULL, failed_attempts = 0 WHERE ${idCol} = ?`).run(userId)
@@ -183,4 +207,4 @@ const logout = async (req, res) => {
   })
 }
 
-module.exports = { showLogin, login, logout, showLoginPin, verifyLoginPin }
+module.exports = { showLogin, login, logout, showLoginPin, resendLoginPin, verifyLoginPin }

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -24,18 +24,21 @@ const _recordFailedAttempt = async (userId, table, email) => {
   const pinTriggered = attempts === 4 ? 1 : 0
   db.prepare('INSERT INTO failed_login_log (identifier, pin_triggered) VALUES (?, ?)').run(String(userId), pinTriggered)
 
+  let pinSent = false
   if (attempts === 4) {
     const pin = String(Math.floor(100000 + Math.random() * 900000))
     const pinHash = crypto.createHash('sha256').update(pin).digest('hex')
     db.prepare(`UPDATE ${table} SET login_pin = ? WHERE ${idCol} = ?`).run(pinHash, userId)
     try {
       await sendLoginWarningEmail(email, pin)
+      pinSent = true
     } catch (err) {
       console.error('Login warning email failed to send:', err)
     }
   }
 
   await logActivity(String(userId), ActionTypes.AUTH_FAILED_LOGIN, [])
+  return { attempts, pinSent }
 }
 
 const login = async (req, res) => {
@@ -43,18 +46,18 @@ const login = async (req, res) => {
 
   const staff = db.prepare('SELECT * FROM staff WHERE staff_number = ?').get(staffStudentNumber)
   if (staff) {
+    if (staff.login_pin) {
+      req.session.pendingUserId = staff.staff_number
+      req.session.pendingUserRole = 'lecturer'
+      req.session.pendingUserName = staff.name
+      return res.redirect('/login/pin')
+    }
     if (staff.password === password) {
       if (!staff.email_verified) {
         return res.render('login', {
           error: 'Your email address has not been verified. Please check your inbox.',
           success: null,
         })
-      }
-      if (staff.login_pin) {
-        req.session.pendingUserId = staff.staff_number
-        req.session.pendingUserRole = 'lecturer'
-        req.session.pendingUserName = staff.name
-        return res.redirect('/login/pin')
       }
       db.prepare('UPDATE staff SET failed_attempts = 0 WHERE staff_number = ?').run(staff.staff_number)
       req.session.userId = staff.staff_number
@@ -64,24 +67,34 @@ const login = async (req, res) => {
       await logActivity(staff.staff_number, ActionTypes.USER_LOGIN, [])
       return res.redirect('/lecturer/dashboard?welcome=1')
     }
-    await _recordFailedAttempt(staff.staff_number, 'staff', staff.email)
-    return res.render('login', { error: 'Invalid username or password.', success: null })
+    const { attempts, pinSent } = await _recordFailedAttempt(staff.staff_number, 'staff', staff.email)
+    if (attempts >= 4) {
+      const msg = pinSent
+        ? 'Too many failed attempts. A security PIN has been sent to your email — you will need it to log in.'
+        : 'Too many failed attempts. A security PIN was already sent to your email. Check your inbox.'
+      return res.render('login', { error: msg, success: null })
+    }
+    const remaining = 4 - attempts
+    return res.render('login', {
+      error: `Invalid username or password. ${remaining} attempt${remaining === 1 ? '' : 's'} remaining before account lockout.`,
+      success: null
+    })
   }
 
   const student = db.prepare('SELECT * FROM students WHERE student_number = ?').get(staffStudentNumber)
   if (student) {
+    if (student.login_pin) {
+      req.session.pendingUserId = student.student_number
+      req.session.pendingUserRole = 'student'
+      req.session.pendingUserName = student.name
+      return res.redirect('/login/pin')
+    }
     if (student.password === password) {
       if (!student.email_verified) {
         return res.render('login', {
           error: 'Your email address has not been verified. Please check your inbox.',
           success: null,
         })
-      }
-      if (student.login_pin) {
-        req.session.pendingUserId = student.student_number
-        req.session.pendingUserRole = 'student'
-        req.session.pendingUserName = student.name
-        return res.redirect('/login/pin')
       }
       db.prepare('UPDATE students SET failed_attempts = 0 WHERE student_number = ?').run(student.student_number)
       req.session.userId = student.student_number
@@ -91,8 +104,18 @@ const login = async (req, res) => {
       await logActivity(student.student_number, ActionTypes.USER_LOGIN, [])
       return res.redirect('/student/dashboard?welcome=1')
     }
-    await _recordFailedAttempt(student.student_number, 'students', student.email)
-    return res.render('login', { error: 'Invalid username or password.', success: null })
+    const { attempts, pinSent } = await _recordFailedAttempt(student.student_number, 'students', student.email)
+    if (attempts >= 4) {
+      const msg = pinSent
+        ? 'Too many failed attempts. A security PIN has been sent to your email — you will need it to log in.'
+        : 'Too many failed attempts. A security PIN was already sent to your email. Check your inbox.'
+      return res.render('login', { error: msg, success: null })
+    }
+    const remaining = 4 - attempts
+    return res.render('login', {
+      error: `Invalid username or password. ${remaining} attempt${remaining === 1 ? '' : 's'} remaining before account lockout.`,
+      success: null
+    })
   }
 
   let admin = null

--- a/src/controllers/signup-controller.js
+++ b/src/controllers/signup-controller.js
@@ -1,6 +1,8 @@
+const crypto = require('crypto')
 const db = require('../../database/db')
 const { logActivity } = require('../services/logging-service')
 const ActionTypes = require('../services/action-types')
+const { sendVerificationEmail } = require('../services/email-service')
 
 const showSignupPage = (req, res) => {
   res.render('sign-up', {
@@ -11,6 +13,25 @@ const showSignupPage = (req, res) => {
     number: '',
     email: ''
   })
+}
+
+const _issueVerificationCode = async (email) => {
+  const code = String(Math.floor(100000 + Math.random() * 900000))
+  const token = crypto.createHash('sha256').update(code).digest('hex')
+  const expiry = new Date(Date.now() + 30 * 60 * 1000).toISOString()
+
+  const inStaff = db.prepare('SELECT 1 FROM staff WHERE email = ?').get(email)
+  if (inStaff) {
+    db.prepare('UPDATE staff SET verification_token = ?, token_expiry = ?, resend_count = 0 WHERE email = ?').run(token, expiry, email)
+  } else {
+    db.prepare('UPDATE students SET verification_token = ?, token_expiry = ?, resend_count = 0 WHERE email = ?').run(token, expiry, email)
+  }
+
+  try {
+    await sendVerificationEmail(email, code)
+  } catch (err) {
+    console.error('Verification email failed to send:', err)
+  }
 }
 
 const registerUser = async (req, res) => {
@@ -88,20 +109,9 @@ const registerUser = async (req, res) => {
       `)
       stmt.run(number, fullName, email, 'EIE', 'EIE', password)
 
-      req.session.userId = number
-      req.session.userName = fullName
-      req.session.userRole = 'lecturer'
-      req.session.showWelcome = true
-
-      await logActivity(req.session.userId, ActionTypes.USER_SIGNUP, [{ table: 'staff', id: req.session.userId }])
-      return res.render('sign-up', {
-        message: 'Account created! Redirecting you to select your courses...',
-        error: null,
-        redirectTo: '/lecturer/courses',
-        fullName: '',
-        number: '',
-        email: ''
-      })
+      await logActivity(number, ActionTypes.USER_SIGNUP, [{ table: 'staff', id: number }])
+      await _issueVerificationCode(email)
+      return res.redirect(`/verify-email?email=${encodeURIComponent(email)}`)
     } else {
       const db_number = db.prepare(`
         SELECT student_number FROM students WHERE student_number = ?
@@ -123,20 +133,9 @@ const registerUser = async (req, res) => {
       `)
       stmt.run(parseInt(number), fullName, email, password, 'BSCENGINFO')
 
-      req.session.userId = parseInt(number)
-      req.session.userName = fullName
-      req.session.userRole = 'student'
-      req.session.showWelcome = true
-
-      await logActivity(req.session.userId, ActionTypes.USER_SIGNUP, [{ table: 'students', id: req.session.userId }])
-      return res.render('sign-up', {
-        message: 'Account created! Redirecting you to select your courses...',
-        error: null,
-        redirectTo: '/student/courses',
-        fullName: '',
-        number: '',
-        email: ''
-      })
+      await logActivity(parseInt(number), ActionTypes.USER_SIGNUP, [{ table: 'students', id: parseInt(number) }])
+      await _issueVerificationCode(email)
+      return res.redirect(`/verify-email?email=${encodeURIComponent(email)}`)
     }
   } catch (error) {
     console.error('Signup error:', error)

--- a/src/controllers/signup-controller.js
+++ b/src/controllers/signup-controller.js
@@ -29,8 +29,10 @@ const _issueVerificationCode = async (email) => {
 
   try {
     await sendVerificationEmail(email, code)
+    return true
   } catch (err) {
     console.error('Verification email failed to send:', err)
+    return false
   }
 }
 
@@ -110,8 +112,9 @@ const registerUser = async (req, res) => {
       stmt.run(number, fullName, email, 'EIE', 'EIE', password)
 
       await logActivity(number, ActionTypes.USER_SIGNUP, [{ table: 'staff', id: number }])
-      await _issueVerificationCode(email)
-      return res.redirect(`/verify-email?email=${encodeURIComponent(email)}`)
+      const staffEmailSent = await _issueVerificationCode(email)
+      const staffWarn = staffEmailSent ? '' : '&emailFailed=1'
+      return res.redirect(`/verify-email?email=${encodeURIComponent(email)}${staffWarn}`)
     } else {
       const db_number = db.prepare(`
         SELECT student_number FROM students WHERE student_number = ?
@@ -134,8 +137,9 @@ const registerUser = async (req, res) => {
       stmt.run(parseInt(number), fullName, email, password, 'BSCENGINFO')
 
       await logActivity(parseInt(number), ActionTypes.USER_SIGNUP, [{ table: 'students', id: parseInt(number) }])
-      await _issueVerificationCode(email)
-      return res.redirect(`/verify-email?email=${encodeURIComponent(email)}`)
+      const studentEmailSent = await _issueVerificationCode(email)
+      const studentWarn = studentEmailSent ? '' : '&emailFailed=1'
+      return res.redirect(`/verify-email?email=${encodeURIComponent(email)}${studentWarn}`)
     }
   } catch (error) {
     console.error('Signup error:', error)

--- a/src/controllers/verify-controller.js
+++ b/src/controllers/verify-controller.js
@@ -14,7 +14,10 @@ const lookupByEmail = (email) => {
 
 const showVerifyPage = (req, res) => {
   const email = req.query.email || ''
-  return res.render('verify-email', { email, error: null, message: null })
+  const message = req.query.emailFailed
+    ? 'We had trouble sending your verification email. Use the Resend button below to try again.'
+    : null
+  return res.render('verify-email', { email, error: null, message })
 }
 
 const verifyEmail = (req, res) => {
@@ -96,6 +99,11 @@ const resendCode = async (req, res) => {
     await sendVerificationEmail(email, code)
   } catch (err) {
     console.error('Resend email failed:', err)
+    return res.render('verify-email', {
+      email,
+      error: 'We could not send the email. Please try again later or contact support if the problem persists.',
+      message: null,
+    })
   }
 
   return res.render('verify-email', {

--- a/src/controllers/verify-controller.js
+++ b/src/controllers/verify-controller.js
@@ -1,0 +1,108 @@
+const crypto = require('crypto')
+const db = require('../../database/db')
+const { sendVerificationEmail } = require('../services/email-service')
+
+const hashCode = (code) => crypto.createHash('sha256').update(code).digest('hex')
+
+const lookupByEmail = (email) => {
+  const student = db.prepare('SELECT * FROM students WHERE email = ?').get(email)
+  if (student) return { user: student, table: 'students', idCol: 'student_number' }
+  const staff = db.prepare('SELECT * FROM staff WHERE email = ?').get(email)
+  if (staff) return { user: staff, table: 'staff', idCol: 'staff_number' }
+  return null
+}
+
+const showVerifyPage = (req, res) => {
+  const email = req.query.email || ''
+  return res.render('verify-email', { email, error: null, message: null })
+}
+
+const verifyEmail = (req, res) => {
+  const { email, code } = req.body
+
+  const found = lookupByEmail(email)
+  if (!found) {
+    return res.render('verify-email', {
+      email,
+      error: 'No account found for this email address.',
+      message: null,
+    })
+  }
+
+  const { user } = found
+
+  if (user.email_verified) {
+    return res.redirect('/login?success=Email+already+verified.+Please+log+in.')
+  }
+
+  if (!user.token_expiry || new Date() > new Date(user.token_expiry)) {
+    return res.render('verify-email', {
+      email,
+      error: 'Your verification code has expired. Please request a new one.',
+      message: null,
+    })
+  }
+
+  if (hashCode(code) !== user.verification_token) {
+    return res.render('verify-email', {
+      email,
+      error: 'Incorrect verification code. Please try again.',
+      message: null,
+    })
+  }
+
+  db.prepare(
+    `UPDATE ${found.table} SET email_verified = 1, verification_token = NULL, token_expiry = NULL, resend_count = 0 WHERE ${found.idCol} = ?`
+  ).run(user[found.idCol])
+
+  return res.redirect('/login?success=Email+verified+successfully.+You+may+now+log+in.')
+}
+
+const resendCode = async (req, res) => {
+  const { email } = req.body
+
+  const found = lookupByEmail(email)
+  if (!found) {
+    return res.render('verify-email', {
+      email,
+      error: 'No account found for this email address.',
+      message: null,
+    })
+  }
+
+  const { user } = found
+
+  if (user.email_verified) {
+    return res.redirect('/login?success=Email+already+verified.+Please+log+in.')
+  }
+
+  if (user.resend_count >= 3) {
+    return res.render('verify-email', {
+      email,
+      error: 'Maximum resend attempts reached. Please contact support.',
+      message: null,
+    })
+  }
+
+  const code = String(Math.floor(100000 + Math.random() * 900000))
+  const token = hashCode(code)
+  const expiry = new Date(Date.now() + 30 * 60 * 1000).toISOString()
+
+  db.prepare(
+    `UPDATE ${found.table} SET verification_token = ?, token_expiry = ?, resend_count = resend_count + 1 WHERE ${found.idCol} = ?`
+  ).run(token, expiry, user[found.idCol])
+
+  try {
+    await sendVerificationEmail(email, code)
+  } catch (err) {
+    console.error('Resend email failed:', err)
+  }
+
+  return res.render('verify-email', {
+    email,
+    error: null,
+    message: 'A new code has been sent to your email.',
+  })
+}
+
+module.exports = { showVerifyPage, verifyEmail, resendCode }

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { showLogin, login, logout, showLoginPin, verifyLoginPin } = require('../controllers/auth-controller');
+const { showLogin, login, logout, showLoginPin, resendLoginPin, verifyLoginPin } = require('../controllers/auth-controller');
 const { showVerifyPage, verifyEmail, resendCode } = require('../controllers/verify-controller');
 
 const router = express.Router();
@@ -10,6 +10,7 @@ router.post('/logout', logout);
 
 router.get('/login/pin', showLoginPin);
 router.post('/login/pin', verifyLoginPin);
+router.post('/login/pin/resend', resendLoginPin);
 
 router.get('/verify-email', showVerifyPage);
 router.post('/verify-email', verifyEmail);

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { showLogin, login, logout } = require('../controllers/auth-controller');
+const { showLogin, login, logout, showLoginPin, verifyLoginPin } = require('../controllers/auth-controller');
 const { showVerifyPage, verifyEmail, resendCode } = require('../controllers/verify-controller');
 
 const router = express.Router();
@@ -7,6 +7,9 @@ const router = express.Router();
 router.get('/login', showLogin);
 router.post('/login', login);
 router.post('/logout', logout);
+
+router.get('/login/pin', showLoginPin);
+router.post('/login/pin', verifyLoginPin);
 
 router.get('/verify-email', showVerifyPage);
 router.post('/verify-email', verifyEmail);

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -1,10 +1,15 @@
 const express = require('express');
 const { showLogin, login, logout } = require('../controllers/auth-controller');
+const { showVerifyPage, verifyEmail, resendCode } = require('../controllers/verify-controller');
 
 const router = express.Router();
 
 router.get('/login', showLogin);
 router.post('/login', login);
 router.post('/logout', logout);
+
+router.get('/verify-email', showVerifyPage);
+router.post('/verify-email', verifyEmail);
+router.post('/verify-email/resend', resendCode);
 
 module.exports = router;

--- a/src/services/email-service.js
+++ b/src/services/email-service.js
@@ -1,0 +1,72 @@
+const nodemailer = require('nodemailer')
+
+const createTransport = () =>
+  nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT) || 587,
+    secure: Number(process.env.SMTP_PORT) === 465,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  })
+
+const sendVerificationEmail = async (toAddress, code) => {
+  const transporter = createTransport()
+
+  const html = `
+    <div style="font-family: 'Segoe UI', Arial, sans-serif; background: #f4f6f3; padding: 40px 0;">
+      <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 2px 12px rgba(0,0,0,0.08);">
+
+        <!-- Header -->
+        <div style="background: #2d5a27; padding: 28px 32px;">
+          <div style="color: #ffffff; font-size: 22px; font-weight: 700; letter-spacing: -0.3px;">
+            🚪 KnockKnock.prof
+          </div>
+          <div style="color: #a8d5a2; font-size: 13px; margin-top: 4px;">
+            Open the door to better consultations
+          </div>
+        </div>
+
+        <!-- Body -->
+        <div style="padding: 36px 32px;">
+          <h2 style="color: #1a2e18; font-size: 20px; margin: 0 0 12px;">Verify your Wits email address</h2>
+          <p style="color: #4a5568; font-size: 15px; line-height: 1.6; margin: 0 0 28px;">
+            Use the code below to verify your Wits email address and activate your account.
+          </p>
+
+          <!-- Code box -->
+          <div style="background: #f0f7ee; border: 2px solid #2d5a27; border-radius: 10px; padding: 24px; text-align: center; margin-bottom: 24px;">
+            <div style="font-size: 42px; font-weight: 800; letter-spacing: 10px; color: #2d5a27; font-variant-numeric: tabular-nums;">
+              ${code}
+            </div>
+          </div>
+
+          <p style="color: #718096; font-size: 13px; text-align: center; margin: 0 0 8px;">
+            ⏱ This code expires in <strong>30 minutes</strong>.
+          </p>
+          <p style="color: #718096; font-size: 13px; text-align: center; margin: 0;">
+            Enter it on the verification page to complete your signup.
+          </p>
+        </div>
+
+        <!-- Footer -->
+        <div style="background: #f4f6f3; padding: 20px 32px; border-top: 1px solid #e2e8df;">
+          <p style="color: #a0aec0; font-size: 12px; margin: 0; text-align: center;">
+            If you did not create an account on KnockKnock.prof, you can safely ignore this email.
+          </p>
+        </div>
+
+      </div>
+    </div>
+  `
+
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM || '"KnockKnock.prof" <no-reply@knockknock.prof>',
+    to: toAddress,
+    subject: 'KnockKnock.prof — Verify your email',
+    html,
+  })
+}
+
+module.exports = { sendVerificationEmail }

--- a/src/services/email-service.js
+++ b/src/services/email-service.js
@@ -69,4 +69,64 @@ const sendVerificationEmail = async (toAddress, code) => {
   })
 }
 
-module.exports = { sendVerificationEmail }
+const sendLoginWarningEmail = async (toAddress, pin) => {
+  const transporter = createTransport()
+
+  const html = `
+    <div style="font-family: 'Segoe UI', Arial, sans-serif; background: #fdf4f4; padding: 40px 0;">
+      <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 2px 12px rgba(0,0,0,0.08);">
+
+        <!-- Header -->
+        <div style="background: #b91c1c; padding: 28px 32px;">
+          <div style="color: #ffffff; font-size: 22px; font-weight: 700; letter-spacing: -0.3px;">
+            KnockKnock.prof — Security Alert
+          </div>
+          <div style="color: #fca5a5; font-size: 13px; margin-top: 4px;">
+            Unusual login activity detected
+          </div>
+        </div>
+
+        <!-- Body -->
+        <div style="padding: 36px 32px;">
+          <h2 style="color: #7f1d1d; font-size: 20px; margin: 0 0 12px;">Multiple failed login attempts</h2>
+          <p style="color: #4a5568; font-size: 15px; line-height: 1.6; margin: 0 0 20px;">
+            We detected 4 consecutive failed login attempts on your KnockKnock.prof account.
+            To protect your account, a one-time PIN is now required for your next login.
+          </p>
+
+          <!-- PIN box -->
+          <div style="background: #fff1f2; border: 2px solid #b91c1c; border-radius: 10px; padding: 24px; text-align: center; margin-bottom: 24px;">
+            <div style="font-size: 13px; color: #7f1d1d; margin-bottom: 8px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;">Your one-time PIN</div>
+            <div style="font-size: 42px; font-weight: 800; letter-spacing: 10px; color: #b91c1c; font-variant-numeric: tabular-nums;">
+              ${pin}
+            </div>
+          </div>
+
+          <p style="color: #718096; font-size: 13px; text-align: center; margin: 0 0 8px;">
+            Enter this PIN alongside your password on your next login.
+          </p>
+          <p style="color: #718096; font-size: 13px; text-align: center; margin: 0;">
+            If this wasn't you, contact your system administrator immediately.
+          </p>
+        </div>
+
+        <!-- Footer -->
+        <div style="background: #fff1f2; padding: 20px 32px; border-top: 1px solid #fecaca;">
+          <p style="color: #a0aec0; font-size: 12px; margin: 0; text-align: center;">
+            This is an automated security alert from KnockKnock.prof. Do not share this PIN with anyone.
+          </p>
+        </div>
+
+      </div>
+    </div>
+  `
+
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM || '"KnockKnock.prof" <no-reply@knockknock.prof>',
+    to: toAddress,
+    subject: 'KnockKnock.prof — Security Alert: Multiple failed login attempts',
+    html,
+  })
+}
+
+module.exports = { sendVerificationEmail, sendLoginWarningEmail }

--- a/src/views/admin-dashboard.html
+++ b/src/views/admin-dashboard.html
@@ -183,7 +183,8 @@ function formatCol(name) {
       <a href="/admin/table/lecturer_availability" class="table-link <%= activeTable === 'lecturer_availability' ? 'active' : '' %>"><i class="bi bi-clock-history me-1"></i>Lecturer Availability</a>
 
       <span class="adm-nav-label">Security</span>
-      <a href="/admin/table/admin_audit_log" class="table-link <%= activeTable === 'admin_audit_log' ? 'active' : '' %>"><i class="bi bi-shield-lock me-1"></i>Audit Log</a>
+      <a href="/admin/table/admin_audit_log"   class="table-link <%= activeTable === 'admin_audit_log'   ? 'active' : '' %>"><i class="bi bi-shield-lock me-1"></i>Audit Log</a>
+      <a href="/admin/table/failed_login_log"  class="table-link <%= activeTable === 'failed_login_log'  ? 'active' : '' %>"><i class="bi bi-exclamation-triangle me-1"></i>Failed Logins</a>
     </div>
 
     <!-- Main -->

--- a/src/views/login-pin.html
+++ b/src/views/login-pin.html
@@ -42,6 +42,10 @@
         <div class="alert alert-danger"><%= error %></div>
       <% } %>
 
+      <% if (typeof message !== 'undefined' && message) { %>
+        <div class="alert alert-success"><%= message %></div>
+      <% } %>
+
       <form action="/login/pin" method="POST">
         <div class="mb-4">
           <label for="pin" class="form-label fw-semibold">One-time PIN</label>
@@ -63,7 +67,12 @@
         <button type="submit" class="btn btn-danger w-100 py-2 mb-3">Verify PIN</button>
       </form>
 
-      <div class="text-center">
+      <div class="text-center d-flex flex-column gap-2">
+        <form action="/login/pin/resend" method="POST" class="d-inline">
+          <button type="submit" class="btn btn-link btn-sm p-0 text-decoration-none">
+            Didn't receive it? Resend PIN
+          </button>
+        </form>
         <a href="/login" class="btn btn-link btn-sm p-0 text-decoration-none text-muted">
           Back to login
         </a>

--- a/src/views/login-pin.html
+++ b/src/views/login-pin.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Security verification — KnockKnock.prof</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/theme.css">
+  <style>
+    .auth-wrapper { min-height: calc(100vh - 75px); display: flex; align-items: center; justify-content: center; }
+    .auth-card    { width: 100%; max-width: 460px; }
+    .code-input   { font-size: 2rem; font-weight: 700; letter-spacing: 0.4em; text-align: center; }
+    .alert-icon   { font-size: 2.5rem; color: #b91c1c; }
+  </style>
+</head>
+<body>
+
+  <header class="topbar p-3 d-flex justify-content-between align-items-center">
+    <a class="navbar-brand d-flex align-items-center gap-2" href="/">
+      <img src="/images/door-logo-transparent.svg" alt="KnockKnock.prof door logo" class="kk-door-logo">
+      <div>
+        <div class="kk-brand-name">KnockKnock.prof</div>
+        <div class="kk-brand-tagline">Open the door to better consultations</div>
+      </div>
+    </a>
+  </header>
+
+  <main class="container-fluid p-4 auth-wrapper">
+    <div class="card p-4 auth-card border-danger-subtle">
+
+      <div class="text-center mb-4">
+        <i class="bi bi-shield-exclamation alert-icon"></i>
+        <h3 class="fw-bold mt-2">Security verification required</h3>
+        <p class="text-muted mb-0">
+          Multiple failed login attempts were detected on your account.
+          Check your email for a one-time PIN and enter it below.
+        </p>
+      </div>
+
+      <% if (typeof error !== 'undefined' && error) { %>
+        <div class="alert alert-danger"><%= error %></div>
+      <% } %>
+
+      <form action="/login/pin" method="POST">
+        <div class="mb-4">
+          <label for="pin" class="form-label fw-semibold">One-time PIN</label>
+          <input
+            type="text"
+            class="form-control code-input"
+            id="pin"
+            name="pin"
+            maxlength="6"
+            pattern="[0-9]{6}"
+            placeholder="000000"
+            inputmode="numeric"
+            autocomplete="one-time-code"
+            required
+          >
+          <div class="form-text text-center">Enter the 6-digit PIN from your security alert email.</div>
+        </div>
+
+        <button type="submit" class="btn btn-danger w-100 py-2 mb-3">Verify PIN</button>
+      </form>
+
+      <div class="text-center">
+        <a href="/login" class="btn btn-link btn-sm p-0 text-decoration-none text-muted">
+          Back to login
+        </a>
+      </div>
+
+    </div>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/views/verify-email.html
+++ b/src/views/verify-email.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify your email — KnockKnock.prof</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/theme.css">
+  <style>
+    .auth-wrapper { min-height: calc(100vh - 75px); display: flex; align-items: center; justify-content: center; }
+    .auth-card    { width: 100%; max-width: 460px; }
+    .code-input   { font-size: 2rem; font-weight: 700; letter-spacing: 0.4em; text-align: center; }
+  </style>
+</head>
+<body>
+
+  <header class="topbar p-3 d-flex justify-content-between align-items-center">
+    <a class="navbar-brand d-flex align-items-center gap-2" href="/">
+      <img src="/images/door-logo-transparent.svg" alt="KnockKnock.prof door logo" class="kk-door-logo">
+      <div>
+        <div class="kk-brand-name">KnockKnock.prof</div>
+        <div class="kk-brand-tagline">Open the door to better consultations</div>
+      </div>
+    </a>
+  </header>
+
+  <main class="container-fluid p-4 auth-wrapper">
+    <div class="card p-4 auth-card">
+
+      <div class="text-center mb-4">
+        <div style="font-size:2.5rem;">📬</div>
+        <h3 class="fw-bold mt-2">Check your inbox</h3>
+        <p class="text-muted mb-0">
+          We sent a 6-digit code to <strong><%= email %></strong>
+        </p>
+      </div>
+
+      <% if (typeof error !== 'undefined' && error) { %>
+        <div class="alert alert-danger"><%= error %></div>
+      <% } %>
+
+      <% if (typeof message !== 'undefined' && message) { %>
+        <div class="alert alert-success"><%= message %></div>
+      <% } %>
+
+      <form action="/verify-email" method="POST">
+        <input type="hidden" name="email" value="<%= email %>">
+
+        <div class="mb-4">
+          <label for="code" class="form-label fw-semibold">Verification code</label>
+          <input
+            type="text"
+            class="form-control code-input"
+            id="code"
+            name="code"
+            maxlength="6"
+            pattern="[0-9]{6}"
+            placeholder="000000"
+            inputmode="numeric"
+            autocomplete="one-time-code"
+            required
+          >
+          <div class="form-text text-center">Enter the 6-digit code from your email. It expires in 30 minutes.</div>
+        </div>
+
+        <button type="submit" class="btn btn-primary w-100 py-2 mb-3">Verify</button>
+      </form>
+
+      <div class="text-center">
+        <form action="/verify-email/resend" method="POST" class="d-inline">
+          <input type="hidden" name="email" value="<%= email %>">
+          <button type="submit" class="btn btn-link btn-sm p-0 text-decoration-none">
+            Didn't receive it? Resend code
+          </button>
+        </form>
+      </div>
+
+    </div>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/tests/e2e/booking-flow.spec.js
+++ b/tests/e2e/booking-flow.spec.js
@@ -9,7 +9,10 @@ const purgeE2ERows = () => {
   }
 };
 
-test.beforeAll(purgeE2ERows);
+test.beforeAll(() => {
+  purgeE2ERows();
+  db.prepare('UPDATE students SET failed_attempts = 0, login_pin = NULL WHERE student_number = 1234567').run();
+});
 test.afterEach(purgeE2ERows);
 
 test('student can book a consultation via the 10-day calendar', async ({ page }) => {

--- a/tests/e2e/cancellation.spec.js
+++ b/tests/e2e/cancellation.spec.js
@@ -11,7 +11,10 @@ const purgeE2ECancelRows = () => {
   }
 };
 
-test.beforeAll(purgeE2ECancelRows);
+test.beforeAll(() => {
+  purgeE2ECancelRows();
+  db.prepare('UPDATE students SET failed_attempts = 0, login_pin = NULL WHERE student_number = 1234567').run();
+});
 test.afterEach(purgeE2ECancelRows);
 
 test('organiser can cancel their own consultation', async ({ page }) => {

--- a/tests/e2e/cancellation.spec.js
+++ b/tests/e2e/cancellation.spec.js
@@ -97,6 +97,35 @@ test('non-organiser attendee can leave a consultation', async ({ page }) => {
   db.prepare('DELETE FROM consultation_attendees WHERE const_id = ? AND student_number = 1234567').run(row.const_id);
 });
 
-test.skip('student can join a joinable consultation', async ({ page }) => {
-  // TODO: Enable once dashboard join link is updated to POST (PR pending)
+test('student can join a joinable consultation', async ({ page }) => {
+  const constId = 'E2E-CANCEL-JOIN-001';
+  const d = new Date(Date.now() + 2 * 60 * 60 * 1000);
+  d.setUTCDate(d.getUTCDate() + 1);
+  while (d.getUTCDay() === 0 || d.getUTCDay() === 6) d.setUTCDate(d.getUTCDate() + 1);
+  const dateStr = d.toISOString().split('T')[0];
+
+  db.prepare('DELETE FROM consultation_attendees WHERE const_id = ?').run(constId);
+  db.prepare('DELETE FROM consultations WHERE const_id = ?').run(constId);
+  db.prepare(`
+    INSERT INTO consultations
+      (const_id, consultation_title, consultation_date, consultation_time,
+       lecturer_id, duration_min, max_number_of_students, venue, status, allow_join)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(constId, 'E2E Cancel Test Join', dateStr, '10:00',
+         'A000356', 60, 5, 'Room 101', 'Booked', 1);
+
+  await page.goto('/login');
+  await page.fill('input[name="staffStudentNumber"]', '1234567');
+  await page.fill('input[name="password"]', 'pass');
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/student/dashboard**');
+
+  await page.goto(`/consultations/${constId}`);
+  await page.getByRole('button', { name: 'Join Consultation' }).click();
+
+  await expect(page).toHaveURL(/student/);
+  await expect(page.locator('body')).toContainText('Successfully joined consultation');
+
+  db.prepare('DELETE FROM consultation_attendees WHERE const_id = ?').run(constId);
+  db.prepare('DELETE FROM consultations WHERE const_id = ?').run(constId);
 });

--- a/tests/e2e/student-join-consultation.spec.js
+++ b/tests/e2e/student-join-consultation.spec.js
@@ -24,6 +24,7 @@ const insertConsultation = (constId, maxStudents = 5) => {
 };
 
 test.beforeEach(() => {
+  db.prepare('UPDATE students SET failed_attempts = 0, login_pin = NULL WHERE student_number = 1234567').run();
   insertConsultation(JOIN_ID, 5);
 });
 

--- a/tests/integration/greeting.test.js
+++ b/tests/integration/greeting.test.js
@@ -8,16 +8,16 @@ const db = require('../../database/db');
 beforeAll(() => {
   db.prepare(`
     INSERT OR IGNORE INTO staff
-      (staff_number, name, email, department, dept_code, password)
+      (staff_number, name, email, department, dept_code, password, email_verified)
     VALUES
-      ('A999001', 'Test Lecturer', 'testlecturer@wits.ac.za', 'EIE', 'EIE', 'testpass')
+      ('A999001', 'Test Lecturer', 'testlecturer@wits.ac.za', 'EIE', 'EIE', 'testpass', 1)
   `).run();
 
   db.prepare(`
     INSERT OR IGNORE INTO students
-      (student_number, name, email, password, degree_code)
+      (student_number, name, email, password, degree_code, email_verified)
     VALUES
-      (9999001, 'Test Student', 'teststudent@students.wits.ac.za', 'testpass', 'BSCENGINFO')
+      (9999001, 'Test Student', 'teststudent@students.wits.ac.za', 'testpass', 'BSCENGINFO', 1)
   `).run();
 });
 

--- a/tests/integration/homepage.test.js
+++ b/tests/integration/homepage.test.js
@@ -6,14 +6,14 @@ const db = require('../../database/db')
 beforeAll(() => {
   db.prepare(`
     INSERT OR IGNORE INTO staff
-      (staff_number, name, email, department, dept_code, password)
-    VALUES ('HP999001', 'HP Lecturer', 'hplecturer@wits.ac.za', 'EIE', 'EIE', 'testpass')
+      (staff_number, name, email, department, dept_code, password, email_verified)
+    VALUES ('HP999001', 'HP Lecturer', 'hplecturer@wits.ac.za', 'EIE', 'EIE', 'testpass', 1)
   `).run()
 
   db.prepare(`
     INSERT OR IGNORE INTO students
-      (student_number, name, email, password, degree_code)
-    VALUES (8888001, 'HP Student', 'hpstudent@students.wits.ac.za', 'testpass', 'BSCENGINFO')
+      (student_number, name, email, password, degree_code, email_verified)
+    VALUES (8888001, 'HP Student', 'hpstudent@students.wits.ac.za', 'testpass', 'BSCENGINFO', 1)
   `).run()
 })
 

--- a/tests/integration/verifyEmail.test.js
+++ b/tests/integration/verifyEmail.test.js
@@ -5,7 +5,8 @@ const app = require('../../app')
 const db = require('../../database/db')
 
 jest.mock('../../src/services/email-service', () => ({
-  sendVerificationEmail: jest.fn().mockResolvedValue(undefined)
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+  sendLoginWarningEmail: jest.fn().mockResolvedValue(undefined)
 }))
 
 const hash = (code) => crypto.createHash('sha256').update(code).digest('hex')

--- a/tests/integration/verifyEmail.test.js
+++ b/tests/integration/verifyEmail.test.js
@@ -1,0 +1,128 @@
+/* eslint-env jest */
+const request = require('supertest')
+const crypto = require('crypto')
+const app = require('../../app')
+const db = require('../../database/db')
+
+jest.mock('../../src/services/email-service', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined)
+}))
+
+const hash = (code) => crypto.createHash('sha256').update(code).digest('hex')
+
+const TEST_EMAIL = 'verify.test@students.wits.ac.za'
+const TEST_NUMBER = 9000001
+
+const cleanup = () => {
+  db.prepare('DELETE FROM students WHERE student_number = ?').run(TEST_NUMBER)
+}
+
+beforeAll(cleanup)
+afterAll(cleanup)
+
+const insertUnverified = (token = null, expiry = null, resendCount = 0) => {
+  db.prepare(`
+    INSERT OR REPLACE INTO students
+      (student_number, name, email, password, degree_code, email_verified, verification_token, token_expiry, resend_count)
+    VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?)
+  `).run(TEST_NUMBER, 'Verify Test', TEST_EMAIL, 'pass', 'BSCENGINFO', token, expiry, resendCount)
+}
+
+const futureExpiry = () => new Date(Date.now() + 10 * 60 * 1000).toISOString()
+
+describe('POST /verify-email', () => {
+  test('correct code sets email_verified = 1 and redirects to login', async () => {
+    const code = '482910'
+    insertUnverified(hash(code), futureExpiry())
+
+    const res = await request(app)
+      .post('/verify-email')
+      .type('form')
+      .send({ email: TEST_EMAIL, code })
+
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toContain('/login')
+    expect(res.headers.location).toContain('verified')
+
+    const row = db.prepare('SELECT email_verified FROM students WHERE student_number = ?').get(TEST_NUMBER)
+    expect(row.email_verified).toBe(1)
+  })
+
+  test('incorrect code renders verify page with error', async () => {
+    insertUnverified(hash('111111'), futureExpiry())
+
+    const res = await request(app)
+      .post('/verify-email')
+      .type('form')
+      .send({ email: TEST_EMAIL, code: '999999' })
+
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('Incorrect verification code')
+  })
+
+  test('expired token renders verify page with expiry error', async () => {
+    const expired = new Date(Date.now() - 1000).toISOString()
+    insertUnverified(hash('123456'), expired)
+
+    const res = await request(app)
+      .post('/verify-email')
+      .type('form')
+      .send({ email: TEST_EMAIL, code: '123456' })
+
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('expired')
+  })
+})
+
+describe('POST /verify-email/resend', () => {
+  test('increments resend_count when count < 3 and returns success message', async () => {
+    insertUnverified(null, null, 0)
+
+    const res = await request(app)
+      .post('/verify-email/resend')
+      .type('form')
+      .send({ email: TEST_EMAIL })
+
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('new code has been sent')
+
+    const row = db.prepare('SELECT resend_count FROM students WHERE student_number = ?').get(TEST_NUMBER)
+    expect(row.resend_count).toBe(1)
+  })
+
+  test('returns max attempts error when resend_count >= 3', async () => {
+    insertUnverified(null, null, 3)
+
+    const res = await request(app)
+      .post('/verify-email/resend')
+      .type('form')
+      .send({ email: TEST_EMAIL })
+
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('Maximum resend attempts')
+  })
+})
+
+describe('POST /login — email_verified guard', () => {
+  test('unverified account is denied login with correct password', async () => {
+    insertUnverified()
+
+    const res = await request(app)
+      .post('/login')
+      .type('form')
+      .send({ staffStudentNumber: String(TEST_NUMBER), password: 'pass' })
+
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('has not been verified')
+  })
+
+  test('verified account with correct password redirects to dashboard', async () => {
+    const res = await request(app)
+      .post('/login')
+      .type('form')
+      .send({ staffStudentNumber: '1234567', password: 'pass' })
+
+    expect(res.status).toBe(302)
+    expect(res.headers.location).toContain('/student/dashboard')
+  })
+})

--- a/tests/unit/auth-controller.test.js
+++ b/tests/unit/auth-controller.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-const { showLogin, login, logout, showLoginPin, verifyLoginPin } = require('../../src/controllers/auth-controller')
+const { showLogin, login, logout, showLoginPin, resendLoginPin, verifyLoginPin } = require('../../src/controllers/auth-controller')
 
 jest.mock('../../database/db', () => ({
   prepare: jest.fn()
@@ -253,7 +253,36 @@ describe('showLoginPin', () => {
     const req = mockReq({ session: { pendingUserId: 'A000356', pendingUserRole: 'lecturer' } })
     const res = mockRes()
     showLoginPin(req, res)
-    expect(res.render).toHaveBeenCalledWith('login-pin', { error: null })
+    expect(res.render).toHaveBeenCalledWith('login-pin', { error: null, message: null })
+  })
+})
+
+describe('resendLoginPin', () => {
+  test('redirects to /login if no pending session', async () => {
+    const req = mockReq({ session: {} })
+    const res = mockRes()
+    await resendLoginPin(req, res)
+    expect(res.redirect).toHaveBeenCalledWith('/login')
+  })
+
+  test('generates new PIN, updates DB, sends email, and renders success message', async () => {
+    const { sendLoginWarningEmail } = require('../../src/services/email-service')
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ email: 'clark.kent@wits.ac.za' }) }) // SELECT email
+      .mockReturnValueOnce({ run: jest.fn() })                                                     // UPDATE login_pin
+
+    const req = mockReq({
+      session: { pendingUserId: 'A000356', pendingUserRole: 'lecturer' }
+    })
+    const res = mockRes()
+
+    await resendLoginPin(req, res)
+
+    expect(sendLoginWarningEmail).toHaveBeenCalledWith('clark.kent@wits.ac.za', expect.any(String))
+    expect(res.render).toHaveBeenCalledWith('login-pin', {
+      error: null,
+      message: 'A new PIN has been sent to your email.'
+    })
   })
 })
 

--- a/tests/unit/auth-controller.test.js
+++ b/tests/unit/auth-controller.test.js
@@ -187,7 +187,7 @@ describe('login', () => {
     })
   })
 
-  test('records failed attempt and renders error when staff found but password wrong', async () => {
+  test('records failed attempt and shows remaining attempts when staff password wrong', async () => {
     db.prepare
       .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) })                          // SELECT staff
       .mockReturnValueOnce({ run: jest.fn() })                                                     // UPDATE failed_attempts++
@@ -200,16 +200,16 @@ describe('login', () => {
     await login(req, res)
 
     expect(res.render).toHaveBeenCalledWith('login', {
-      error: 'Invalid username or password.',
+      error: 'Invalid username or password. 3 attempts remaining before account lockout.',
       success: null
     })
   })
 
-  test('redirects to /login/pin when staff has correct password but login_pin is set', async () => {
+  test('redirects to /login/pin when login_pin is set regardless of password', async () => {
     const lockedStaff = { ...fakeStaff, login_pin: 'somehash' }
     db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(lockedStaff) })
 
-    const req = mockReq({ body: { staffStudentNumber: 'A000356', password: 'pass' } })
+    const req = mockReq({ body: { staffStudentNumber: 'A000356', password: 'wrongpass' } })
     const res = mockRes()
 
     await login(req, res)
@@ -219,7 +219,7 @@ describe('login', () => {
     expect(res.redirect).toHaveBeenCalledWith('/login/pin')
   })
 
-  test('sends warning email and stores PIN on 4th failed attempt', async () => {
+  test('sends warning email and shows lockout message on 4th failed attempt', async () => {
     const { sendLoginWarningEmail } = require('../../src/services/email-service')
     db.prepare
       .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) })                                              // SELECT staff
@@ -234,7 +234,10 @@ describe('login', () => {
     await login(req, res)
 
     expect(sendLoginWarningEmail).toHaveBeenCalledWith(fakeStaff.email, expect.any(String))
-    expect(res.render).toHaveBeenCalledWith('login', { error: 'Invalid username or password.', success: null })
+    expect(res.render).toHaveBeenCalledWith('login', {
+      error: 'Too many failed attempts. A security PIN has been sent to your email — you will need it to log in.',
+      success: null
+    })
   })
 })
 

--- a/tests/unit/auth-controller.test.js
+++ b/tests/unit/auth-controller.test.js
@@ -82,8 +82,8 @@ describe('showLogin', () => {
 })
 
 describe('login', () => {
-  const fakeStaff = { staff_number: 'A000356', name: 'Clark Kent', password: 'pass' }
-  const fakeStudent = { student_number: 1234567, name: 'Aditya', password: 'pass' }
+  const fakeStaff = { staff_number: 'A000356', name: 'Clark Kent', password: 'pass', email_verified: 1 }
+  const fakeStudent = { student_number: 1234567, name: 'Aditya', password: 'pass', email_verified: 1 }
 
   test('sets lecturer session and redirects to lecturer dashboard on valid staff credentials', async () => {
     db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) })
@@ -147,6 +147,38 @@ describe('login', () => {
     expect(res.render).toHaveBeenCalledWith('login', {
       error: 'Invalid username or password.',
       success: null
+    })
+  })
+
+  test('renders unverified error when staff password is correct but email not verified', async () => {
+    const unverifiedStaff = { ...fakeStaff, email_verified: 0 }
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(unverifiedStaff) })
+
+    const req = mockReq({ body: { staffStudentNumber: 'A000356', password: 'pass' } })
+    const res = mockRes()
+
+    await login(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('login', {
+      error: 'Your email address has not been verified. Please check your inbox.',
+      success: null,
+    })
+  })
+
+  test('renders unverified error when student password is correct but email not verified', async () => {
+    const unverifiedStudent = { ...fakeStudent, email_verified: 0 }
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(unverifiedStudent) })
+
+    const req = mockReq({ body: { staffStudentNumber: '1234567', password: 'pass' } })
+    const res = mockRes()
+
+    await login(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('login', {
+      error: 'Your email address has not been verified. Please check your inbox.',
+      success: null,
     })
   })
 

--- a/tests/unit/auth-controller.test.js
+++ b/tests/unit/auth-controller.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-const { showLogin, login, logout } = require('../../src/controllers/auth-controller')
+const { showLogin, login, logout, showLoginPin, verifyLoginPin } = require('../../src/controllers/auth-controller')
 
 jest.mock('../../database/db', () => ({
   prepare: jest.fn()
@@ -7,6 +7,11 @@ jest.mock('../../database/db', () => ({
 
 jest.mock('../../src/services/logging-service', () => ({
   logActivity: jest.fn().mockResolvedValue(true)
+}))
+
+jest.mock('../../src/services/email-service', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+  sendLoginWarningEmail: jest.fn().mockResolvedValue(undefined)
 }))
 
 const db = require('../../database/db')
@@ -31,22 +36,29 @@ beforeEach(() => {
   logActivity.mockClear()
 })
 
+const fakeStaff = {
+  staff_number: 'A000356', name: 'Clark Kent', password: 'pass',
+  email: 'clark.kent@wits.ac.za', email_verified: 1,
+  failed_attempts: 0, login_pin: null
+}
+const fakeStudent = {
+  student_number: 1234567, name: 'Aditya', password: 'pass',
+  email: 'aditya@students.wits.ac.za', email_verified: 1,
+  failed_attempts: 0, login_pin: null
+}
+
 describe('showLogin', () => {
   test('renders login page with no error or success when not logged in', () => {
     const req = mockReq({ session: {}, query: {} })
     const res = mockRes()
-
     showLogin(req, res)
-
     expect(res.render).toHaveBeenCalledWith('login', { error: null, success: null })
   })
 
   test('passes success query param through to the login view', () => {
     const req = mockReq({ session: {}, query: { success: 'Account created! Please log in.' } })
     const res = mockRes()
-
     showLogin(req, res)
-
     expect(res.render).toHaveBeenCalledWith('login', {
       error: null,
       success: 'Account created! Please log in.'
@@ -56,37 +68,30 @@ describe('showLogin', () => {
   test('redirects logged-in lecturer to lecturer dashboard', () => {
     const req = mockReq({ session: { userId: 'A000356', userRole: 'lecturer' } })
     const res = mockRes()
-
     showLogin(req, res)
-
     expect(res.redirect).toHaveBeenCalledWith('/lecturer/dashboard')
   })
 
   test('redirects logged-in student to student dashboard', () => {
     const req = mockReq({ session: { userId: 1234567, userRole: 'student' } })
     const res = mockRes()
-
     showLogin(req, res)
-
     expect(res.redirect).toHaveBeenCalledWith('/student/dashboard')
   })
 
   test('redirects logged-in admin to admin dashboard', () => {
     const req = mockReq({ session: { userId: 'ADMIN001', userRole: 'admin' } })
     const res = mockRes()
-
     showLogin(req, res)
-
     expect(res.redirect).toHaveBeenCalledWith('/admin/dashboard')
   })
 })
 
 describe('login', () => {
-  const fakeStaff = { staff_number: 'A000356', name: 'Clark Kent', password: 'pass', email_verified: 1 }
-  const fakeStudent = { student_number: 1234567, name: 'Aditya', password: 'pass', email_verified: 1 }
-
   test('sets lecturer session and redirects to lecturer dashboard on valid staff credentials', async () => {
-    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) })
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) }) // SELECT staff
+      .mockReturnValueOnce({ run: jest.fn() })                            // UPDATE failed_attempts = 0
 
     const req = mockReq({ body: { staffStudentNumber: 'A000356', password: 'pass' } })
     const res = mockRes()
@@ -101,8 +106,9 @@ describe('login', () => {
 
   test('sets student session and redirects to student dashboard on valid student credentials', async () => {
     db.prepare
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStudent) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })        // SELECT staff (not found)
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStudent) }) // SELECT student
+      .mockReturnValueOnce({ run: jest.fn() })                              // UPDATE failed_attempts = 0
 
     const req = mockReq({ body: { staffStudentNumber: '1234567', password: 'pass' } })
     const res = mockRes()
@@ -118,9 +124,9 @@ describe('login', () => {
   test('sets admin session and redirects to admin dashboard on valid admin credentials', async () => {
     const fakeAdmin = { admin_id: 'ADMIN001', name: 'System Admin', password: 'admin' }
     db.prepare
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeAdmin) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })       // SELECT staff
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })       // SELECT student
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeAdmin) })  // SELECT admin
 
     const req = mockReq({ body: { staffStudentNumber: 'ADMIN001', password: 'admin' } })
     const res = mockRes()
@@ -128,7 +134,6 @@ describe('login', () => {
     await login(req, res)
 
     expect(req.session.userId).toBe('ADMIN001')
-    expect(req.session.userName).toBe('System Admin')
     expect(req.session.userRole).toBe('admin')
     expect(res.redirect).toHaveBeenCalledWith('/admin/dashboard')
   })
@@ -182,11 +187,12 @@ describe('login', () => {
     })
   })
 
-  test('renders error when staff is found but password does not match', async () => {
+  test('records failed attempt and renders error when staff found but password wrong', async () => {
     db.prepare
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) })
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) })                          // SELECT staff
+      .mockReturnValueOnce({ run: jest.fn() })                                                     // UPDATE failed_attempts++
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ failed_attempts: 1 }) })             // SELECT new count
+      .mockReturnValueOnce({ run: jest.fn() })                                                     // INSERT failed_login_log
 
     const req = mockReq({ body: { staffStudentNumber: 'A000356', password: 'wrongpass' } })
     const res = mockRes()
@@ -197,6 +203,118 @@ describe('login', () => {
       error: 'Invalid username or password.',
       success: null
     })
+  })
+
+  test('redirects to /login/pin when staff has correct password but login_pin is set', async () => {
+    const lockedStaff = { ...fakeStaff, login_pin: 'somehash' }
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(lockedStaff) })
+
+    const req = mockReq({ body: { staffStudentNumber: 'A000356', password: 'pass' } })
+    const res = mockRes()
+
+    await login(req, res)
+
+    expect(req.session.pendingUserId).toBe('A000356')
+    expect(req.session.pendingUserRole).toBe('lecturer')
+    expect(res.redirect).toHaveBeenCalledWith('/login/pin')
+  })
+
+  test('sends warning email and stores PIN on 4th failed attempt', async () => {
+    const { sendLoginWarningEmail } = require('../../src/services/email-service')
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) })                                              // SELECT staff
+      .mockReturnValueOnce({ run: jest.fn() })                                                                         // UPDATE failed_attempts++
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ failed_attempts: 4 }) })                                 // SELECT new count (4)
+      .mockReturnValueOnce({ run: jest.fn() })                                                                         // INSERT failed_login_log (pin_triggered=1)
+      .mockReturnValueOnce({ run: jest.fn() })                                                                         // UPDATE login_pin
+
+    const req = mockReq({ body: { staffStudentNumber: 'A000356', password: 'wrongpass' } })
+    const res = mockRes()
+
+    await login(req, res)
+
+    expect(sendLoginWarningEmail).toHaveBeenCalledWith(fakeStaff.email, expect.any(String))
+    expect(res.render).toHaveBeenCalledWith('login', { error: 'Invalid username or password.', success: null })
+  })
+})
+
+describe('showLoginPin', () => {
+  test('redirects to /login if no pending session', () => {
+    const req = mockReq({ session: {} })
+    const res = mockRes()
+    showLoginPin(req, res)
+    expect(res.redirect).toHaveBeenCalledWith('/login')
+  })
+
+  test('renders login-pin page when pending session exists', () => {
+    const req = mockReq({ session: { pendingUserId: 'A000356', pendingUserRole: 'lecturer' } })
+    const res = mockRes()
+    showLoginPin(req, res)
+    expect(res.render).toHaveBeenCalledWith('login-pin', { error: null })
+  })
+})
+
+describe('verifyLoginPin', () => {
+  test('redirects to /login if no pending session', async () => {
+    const req = mockReq({ session: {}, body: { pin: '123456' } })
+    const res = mockRes()
+    await verifyLoginPin(req, res)
+    expect(res.redirect).toHaveBeenCalledWith('/login')
+  })
+
+  test('renders error on incorrect PIN', async () => {
+    const correctHash = require('crypto').createHash('sha256').update('999999').digest('hex')
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue({ login_pin: correctHash }) })
+
+    const req = mockReq({
+      session: { pendingUserId: 'A000356', pendingUserRole: 'lecturer', pendingUserName: 'Clark Kent' },
+      body: { pin: '123456' }
+    })
+    const res = mockRes()
+
+    await verifyLoginPin(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('login-pin', expect.objectContaining({ error: expect.any(String) }))
+  })
+
+  test('clears lockout and sets session on correct PIN for lecturer', async () => {
+    const pin = '482910'
+    const pinHash = require('crypto').createHash('sha256').update(pin).digest('hex')
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ login_pin: pinHash }) }) // SELECT login_pin
+      .mockReturnValueOnce({ run: jest.fn() })                                         // UPDATE clear pin
+
+    const req = mockReq({
+      session: { pendingUserId: 'A000356', pendingUserRole: 'lecturer', pendingUserName: 'Clark Kent' },
+      body: { pin }
+    })
+    const res = mockRes()
+
+    await verifyLoginPin(req, res)
+
+    expect(req.session.userId).toBe('A000356')
+    expect(req.session.userRole).toBe('lecturer')
+    expect(res.redirect).toHaveBeenCalledWith('/lecturer/dashboard?welcome=1')
+  })
+
+  test('clears lockout and sets session on correct PIN for student', async () => {
+    const pin = '111222'
+    const pinHash = require('crypto').createHash('sha256').update(pin).digest('hex')
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ login_pin: pinHash }) }) // SELECT login_pin
+      .mockReturnValueOnce({ run: jest.fn() })                                         // UPDATE clear pin
+
+    const req = mockReq({
+      session: { pendingUserId: 1234567, pendingUserRole: 'student', pendingUserName: 'Aditya' },
+      body: { pin }
+    })
+    const res = mockRes()
+
+    await verifyLoginPin(req, res)
+
+    expect(req.session.userId).toBe(1234567)
+    expect(req.session.userRole).toBe('student')
+    expect(res.redirect).toHaveBeenCalledWith('/student/dashboard?welcome=1')
   })
 })
 

--- a/tests/unit/departmentSchema.test.js
+++ b/tests/unit/departmentSchema.test.js
@@ -20,8 +20,8 @@ describe('Department schema constraints and relationships', () => {
     db.prepare(`INSERT INTO departments VALUES ('EIE', 'School of Electrical and Information Engineering', 'Engineering and the Built Environment')`).run()
     db.prepare(`INSERT INTO departments VALUES ('MIA', 'School of Mechanical, Industrial and Aeronautical Engineering', 'Engineering and the Built Environment')`).run()
     db.prepare(`INSERT INTO degrees VALUES ('BSCENGINFO', 'BSc Eng (Information)', 'EIE')`).run()
-    db.prepare(`INSERT INTO students VALUES (1000001, 'Test Student', 'student@wits.ac.za', 'pw', 'BSCENGINFO')`).run()
-    db.prepare(`INSERT INTO staff VALUES ('A000001', 'Dr Alpha', 'alpha@wits.ac.za', 'EIE', 'EIE', 'pw')`).run()
+    db.prepare(`INSERT INTO students (student_number, name, email, password, degree_code) VALUES (1000001, 'Test Student', 'student@wits.ac.za', 'pw', 'BSCENGINFO')`).run()
+    db.prepare(`INSERT INTO staff (staff_number, name, email, department, dept_code, password) VALUES ('A000001', 'Dr Alpha', 'alpha@wits.ac.za', 'EIE', 'EIE', 'pw')`).run()
     db.prepare(`INSERT INTO courses VALUES ('ELEN4010', 'Software Development III', 4, 'EIE')`).run()
     db.prepare(`INSERT INTO courses VALUES ('MECN4020', 'Systems Management and Integration', 4, 'MIA')`).run()
   })
@@ -109,7 +109,7 @@ describe('Department schema constraints and relationships', () => {
   })
 
   test('removes course assignments when a staff member is deleted', () => {
-    db.prepare(`INSERT INTO staff VALUES ('A000099', 'Temp Staff', 'temp@wits.ac.za', 'EIE', 'EIE', 'pw')`).run()
+    db.prepare(`INSERT INTO staff (staff_number, name, email, department, dept_code, password) VALUES ('A000099', 'Temp Staff', 'temp@wits.ac.za', 'EIE', 'EIE', 'pw')`).run()
     db.prepare(`INSERT INTO staff_courses VALUES ('A000099', 'ELEN4010')`).run()
     db.prepare(`DELETE FROM staff WHERE staff_number = 'A000099'`).run()
     const rows = db.prepare(`SELECT * FROM staff_courses WHERE staff_number = 'A000099'`).all()

--- a/tests/unit/signup-controller.test.js
+++ b/tests/unit/signup-controller.test.js
@@ -10,7 +10,8 @@ jest.mock('../../src/services/logging-service', () => ({
 }))
 
 jest.mock('../../src/services/email-service', () => ({
-  sendVerificationEmail: jest.fn().mockResolvedValue(undefined)
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+  sendLoginWarningEmail: jest.fn().mockResolvedValue(undefined)
 }))
 
 const db = require('../../database/db')

--- a/tests/unit/signup-controller.test.js
+++ b/tests/unit/signup-controller.test.js
@@ -9,6 +9,10 @@ jest.mock('../../src/services/logging-service', () => ({
   logActivity: jest.fn().mockResolvedValue(true)
 }))
 
+jest.mock('../../src/services/email-service', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined)
+}))
+
 const db = require('../../database/db')
 const { logActivity } = require('../../src/services/logging-service')
 
@@ -30,15 +34,11 @@ beforeEach(() => {
 describe('email domain validation', () => {
   test('accepts student email ending in @students.wits.ac.za', async () => {
     db.prepare
-      .mockReturnValueOnce({
-        get: jest.fn().mockReturnValue(undefined)
-      })
-      .mockReturnValueOnce({
-        get: jest.fn().mockReturnValue(undefined)
-      })
-      .mockReturnValueOnce({
-        run: jest.fn()
-      })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(undefined) }) // student_number check
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(undefined) }) // email check
+      .mockReturnValueOnce({ run: jest.fn() })                            // INSERT
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })      // staff check in _issueVerificationCode
+      .mockReturnValueOnce({ run: jest.fn() })                            // UPDATE students token
 
     const req = mockReq({
       fullName: 'Test Student',
@@ -47,42 +47,24 @@ describe('email domain validation', () => {
       password: 'pass',
       confirmPassword: 'pass'
     })
-
     req.session = {}
 
     const res = mockRes()
+    await registerUser(req, res)
 
-    await registerUser(req, res) // Await the controller
-
-    expect(req.session.userId).toBe(1234567)
-    expect(req.session.userName).toBe('Test Student')
-    expect(req.session.userRole).toBe('student')
-    expect(req.session.showWelcome).toBe(true)
-
-    expect(res.render).toHaveBeenCalledWith(
-      'sign-up',
-      {
-        message: 'Account created! Redirecting you to select your courses...',
-        error: null,
-        redirectTo: '/student/courses',
-        fullName: '',
-        number: '',
-        email: ''
-      }
+    expect(req.session.userId).toBeUndefined()
+    expect(res.redirect).toHaveBeenCalledWith(
+      '/verify-email?email=student%40students.wits.ac.za'
     )
   })
 
   test('accepts lecturer email ending in @wits.ac.za', async () => {
     db.prepare
-      .mockReturnValueOnce({
-        get: jest.fn().mockReturnValue(undefined)
-      })
-      .mockReturnValueOnce({
-        get: jest.fn().mockReturnValue(undefined)
-      })
-      .mockReturnValueOnce({
-        run: jest.fn()
-      })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(undefined) }) // staff_number check
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(undefined) }) // email check
+      .mockReturnValueOnce({ run: jest.fn() })                            // INSERT
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ staff_number: 'A000999' }) }) // staff check in _issueVerificationCode
+      .mockReturnValueOnce({ run: jest.fn() })                            // UPDATE staff token
 
     const req = mockReq({
       fullName: 'Test Lecturer',
@@ -91,28 +73,14 @@ describe('email domain validation', () => {
       password: 'pass',
       confirmPassword: 'pass'
     })
-
     req.session = {}
 
     const res = mockRes()
+    await registerUser(req, res)
 
-    await registerUser(req, res) // Await the controller
-
-    expect(req.session.userId).toBe('A000999')
-    expect(req.session.userName).toBe('Test Lecturer')
-    expect(req.session.userRole).toBe('lecturer')
-    expect(req.session.showWelcome).toBe(true)
-
-    expect(res.render).toHaveBeenCalledWith(
-      'sign-up',
-      {
-        message: 'Account created! Redirecting you to select your courses...',
-        error: null,
-        redirectTo: '/lecturer/courses',
-        fullName: '',
-        number: '',
-        email: ''
-      }
+    expect(req.session.userId).toBeUndefined()
+    expect(res.redirect).toHaveBeenCalledWith(
+      '/verify-email?email=lecturer%40wits.ac.za'
     )
   })
 

--- a/tests/unit/signup-greeting.test.js
+++ b/tests/unit/signup-greeting.test.js
@@ -9,6 +9,10 @@ jest.mock('../../src/services/logging-service', () => ({
   logActivity: jest.fn().mockResolvedValue(true)
 }))
 
+jest.mock('../../src/services/email-service', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined)
+}))
+
 const { registerUser } = require('../../src/controllers/signup-controller')
 
 const mockReq = (body = {}) => ({ body })
@@ -25,19 +29,14 @@ beforeEach(() => {
   mockPrepare.mockReset()
 })
 
-describe('Sign Up greeting validation', () => {
-  // 3. Added async
-  test('student signup shows success greeting', async () => {
+describe('Sign Up — redirects to verify-email after account creation', () => {
+  test('student signup redirects to verify-email page', async () => {
     mockPrepare
-      .mockReturnValueOnce({
-        get: jest.fn().mockReturnValue(undefined)
-      })
-      .mockReturnValueOnce({
-        get: jest.fn().mockReturnValue(undefined)
-      })
-      .mockReturnValueOnce({
-        run: jest.fn()
-      })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(undefined) }) // check student_number
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(undefined) }) // check email
+      .mockReturnValueOnce({ run: jest.fn() })                            // INSERT student
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })      // SELECT 1 FROM staff (not staff)
+      .mockReturnValueOnce({ run: jest.fn() })                            // UPDATE students token
 
     const req = mockReq({
       fullName: 'Test Student',
@@ -52,35 +51,19 @@ describe('Sign Up greeting validation', () => {
 
     await registerUser(req, res)
 
-    expect(req.session.userId).toBe(2468101)
-    expect(req.session.userName).toBe('Test Student')
-    expect(req.session.userRole).toBe('student')
-    expect(req.session.showWelcome).toBe(true)
-
-    expect(res.render).toHaveBeenCalledWith(
-      'sign-up',
-      {
-        message: 'Account created! Redirecting you to select your courses...',
-        error: null,
-        redirectTo: '/student/courses',
-        fullName: '',
-        number: '',
-        email: ''
-      }
+    expect(res.redirect).toHaveBeenCalledWith(
+      '/verify-email?email=student%40students.wits.ac.za'
     )
+    expect(res.render).not.toHaveBeenCalled()
   })
 
-  test('lecturer signup shows success greeting', async () => {
+  test('lecturer signup redirects to verify-email page', async () => {
     mockPrepare
-      .mockReturnValueOnce({
-        get: jest.fn().mockReturnValue(undefined)
-      })
-      .mockReturnValueOnce({
-        get: jest.fn().mockReturnValue(undefined)
-      })
-      .mockReturnValueOnce({
-        run: jest.fn()
-      })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(undefined) })               // check staff_number
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(undefined) })               // check email
+      .mockReturnValueOnce({ run: jest.fn() })                                          // INSERT staff
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ staff_number: 'A000999' }) }) // SELECT 1 FROM staff (found)
+      .mockReturnValueOnce({ run: jest.fn() })                                          // UPDATE staff token
 
     const req = mockReq({
       fullName: 'Test Lecturer',
@@ -93,24 +76,11 @@ describe('Sign Up greeting validation', () => {
     req.session = {}
     const res = mockRes()
 
-    // 4. Added await
     await registerUser(req, res)
 
-    expect(req.session.userId).toBe('A000999')
-    expect(req.session.userName).toBe('Test Lecturer')
-    expect(req.session.userRole).toBe('lecturer')
-    expect(req.session.showWelcome).toBe(true)
-
-    expect(res.render).toHaveBeenCalledWith(
-      'sign-up',
-      {
-        message: 'Account created! Redirecting you to select your courses...',
-        error: null,
-        redirectTo: '/lecturer/courses',
-        fullName: '',
-        number: '',
-        email: ''
-      }
+    expect(res.redirect).toHaveBeenCalledWith(
+      '/verify-email?email=lecturer%40wits.ac.za'
     )
+    expect(res.render).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/signup-greeting.test.js
+++ b/tests/unit/signup-greeting.test.js
@@ -10,7 +10,8 @@ jest.mock('../../src/services/logging-service', () => ({
 }))
 
 jest.mock('../../src/services/email-service', () => ({
-  sendVerificationEmail: jest.fn().mockResolvedValue(undefined)
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined),
+  sendLoginWarningEmail: jest.fn().mockResolvedValue(undefined)
 }))
 
 const { registerUser } = require('../../src/controllers/signup-controller')

--- a/tests/unit/staffCourses.test.js
+++ b/tests/unit/staffCourses.test.js
@@ -18,8 +18,8 @@ describe('Staff course assignments', () => {
 
     db.prepare(`INSERT INTO departments VALUES ('EIE', 'School of EIE', 'Engineering')`).run()
     db.prepare(`INSERT INTO degrees VALUES ('BSCENGINFO', 'BSc Eng (Information)', 'EIE')`).run()
-    db.prepare(`INSERT INTO staff VALUES ('A000001', 'Dr Alpha', 'alpha@wits.ac.za', 'EIE', 'EIE', 'pw')`).run()
-    db.prepare(`INSERT INTO staff VALUES ('A000002', 'Dr Beta',  'beta@wits.ac.za',  'EIE', 'EIE', 'pw')`).run()
+    db.prepare(`INSERT INTO staff (staff_number, name, email, department, dept_code, password) VALUES ('A000001', 'Dr Alpha', 'alpha@wits.ac.za', 'EIE', 'EIE', 'pw')`).run()
+    db.prepare(`INSERT INTO staff (staff_number, name, email, department, dept_code, password) VALUES ('A000002', 'Dr Beta',  'beta@wits.ac.za',  'EIE', 'EIE', 'pw')`).run()
     db.prepare(`INSERT INTO courses VALUES ('ELEN4010', 'Software Development III', 4, 'EIE')`).run()
     db.prepare(`INSERT INTO courses VALUES ('ELEN3009', 'Digital Systems',           3, 'EIE')`).run()
     db.prepare(`INSERT INTO courses VALUES ('ELEN4020', 'Data Intensive Computing',  4, 'EIE')`).run()
@@ -60,7 +60,7 @@ describe('Staff course assignments', () => {
   })
 
   test('returns an empty list for a lecturer with no course assignments', () => {
-    db.prepare(`INSERT INTO staff VALUES ('A000003', 'Dr Gamma', 'gamma@wits.ac.za', 'EIE', 'EIE', 'pw')`).run()
+    db.prepare(`INSERT INTO staff (staff_number, name, email, department, dept_code, password) VALUES ('A000003', 'Dr Gamma', 'gamma@wits.ac.za', 'EIE', 'EIE', 'pw')`).run()
     const rows = db.prepare(`SELECT * FROM staff_courses WHERE staff_number = 'A000003'`).all()
     expect(rows).toHaveLength(0)
   })

--- a/tests/unit/verify-controller.test.js
+++ b/tests/unit/verify-controller.test.js
@@ -1,0 +1,178 @@
+/* eslint-env jest */
+const crypto = require('crypto')
+
+jest.mock('../../database/db', () => ({ prepare: jest.fn() }))
+jest.mock('../../src/services/email-service', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue(undefined)
+}))
+
+const { verifyEmail, resendCode } = require('../../src/controllers/verify-controller')
+const db = require('../../database/db')
+const { sendVerificationEmail } = require('../../src/services/email-service')
+
+const hash = (code) => crypto.createHash('sha256').update(code).digest('hex')
+
+const mockRes = () => {
+  const res = {}
+  res.render = jest.fn()
+  res.redirect = jest.fn()
+  return res
+}
+
+const mockReq = (body = {}) => ({ body })
+
+const futureExpiry = () => new Date(Date.now() + 10 * 60 * 1000).toISOString()
+const pastExpiry = () => new Date(Date.now() - 1000).toISOString()
+
+beforeEach(() => {
+  db.prepare.mockReset()
+  sendVerificationEmail.mockClear()
+})
+
+describe('POST /verify-email', () => {
+  test('correct code marks account verified and redirects to login', () => {
+    const code = '482910'
+    const fakeUser = {
+      student_number: 9876543,
+      email: 'test@students.wits.ac.za',
+      email_verified: 0,
+      verification_token: hash(code),
+      token_expiry: futureExpiry(),
+    }
+
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeUser) }) // students lookup
+      .mockReturnValueOnce({ run: jest.fn() })                           // UPDATE verified
+
+    const req = mockReq({ email: 'test@students.wits.ac.za', code })
+    const res = mockRes()
+
+    verifyEmail(req, res)
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      '/login?success=Email+verified+successfully.+You+may+now+log+in.'
+    )
+  })
+
+  test('incorrect code renders error', () => {
+    const fakeUser = {
+      student_number: 9876543,
+      email: 'test@students.wits.ac.za',
+      email_verified: 0,
+      verification_token: hash('111111'),
+      token_expiry: futureExpiry(),
+    }
+
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeUser) })
+
+    const req = mockReq({ email: 'test@students.wits.ac.za', code: '999999' })
+    const res = mockRes()
+
+    verifyEmail(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
+      error: 'Incorrect verification code. Please try again.',
+    }))
+  })
+
+  test('expired token renders expiry error', () => {
+    const code = '123456'
+    const fakeUser = {
+      student_number: 9876543,
+      email: 'test@students.wits.ac.za',
+      email_verified: 0,
+      verification_token: hash(code),
+      token_expiry: pastExpiry(),
+    }
+
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeUser) })
+
+    const req = mockReq({ email: 'test@students.wits.ac.za', code })
+    const res = mockRes()
+
+    verifyEmail(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
+      error: 'Your verification code has expired. Please request a new one.',
+    }))
+  })
+
+  test('unknown email renders error', () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) }) // students
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) }) // staff
+
+    const req = mockReq({ email: 'nobody@students.wits.ac.za', code: '000000' })
+    const res = mockRes()
+
+    verifyEmail(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
+      error: 'No account found for this email address.',
+    }))
+  })
+
+  test('already verified redirects to login', () => {
+    const fakeUser = {
+      student_number: 9876543,
+      email_verified: 1,
+      verification_token: null,
+      token_expiry: null,
+    }
+
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeUser) })
+
+    const req = mockReq({ email: 'test@students.wits.ac.za', code: '123456' })
+    const res = mockRes()
+
+    verifyEmail(req, res)
+
+    expect(res.redirect).toHaveBeenCalledWith('/login?success=Email+already+verified.+Please+log+in.')
+  })
+})
+
+describe('POST /verify-email/resend', () => {
+  test('increments resend_count and returns success message when count < 3', async () => {
+    const fakeUser = {
+      student_number: 9876543,
+      email: 'test@students.wits.ac.za',
+      email_verified: 0,
+      resend_count: 1,
+    }
+
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeUser) }) // students lookup
+      .mockReturnValueOnce({ run: jest.fn() })                           // UPDATE token
+
+    const req = mockReq({ email: 'test@students.wits.ac.za' })
+    const res = mockRes()
+
+    await resendCode(req, res)
+
+    expect(sendVerificationEmail).toHaveBeenCalledWith('test@students.wits.ac.za', expect.any(String))
+    expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
+      message: 'A new code has been sent to your email.',
+      error: null,
+    }))
+  })
+
+  test('returns max attempts error when resend_count >= 3', async () => {
+    const fakeUser = {
+      student_number: 9876543,
+      email_verified: 0,
+      resend_count: 3,
+    }
+
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeUser) })
+
+    const req = mockReq({ email: 'test@students.wits.ac.za' })
+    const res = mockRes()
+
+    await resendCode(req, res)
+
+    expect(sendVerificationEmail).not.toHaveBeenCalled()
+    expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
+      error: 'Maximum resend attempts reached. Please contact support.',
+    }))
+  })
+})


### PR DESCRIPTION
# Story #109 — Email Verification on Signup

## Summary

- Adds `email_verified`, `verification_token`, `token_expiry`, and `resend_count` columns to both `students` and `staff` tables in the schema and all seed files
- New `email-service.js` sends a styled HTML verification email via `nodemailer` (SMTP config via `.env`) from `"Knock Knock — It's Verification"`
- New `verify-controller.js` handles:
  - `GET /verify-email`
  - `POST /verify-email`
  - `POST /verify-email/resend`
- Implements:
  - SHA-256 token comparison
  - 30-minute expiry window
  - resend cap of 3
- `signup-controller.js` now redirects to `/verify-email` after account creation instead of logging in immediately
- `auth-controller.js` blocks login for unverified accounts with a clear error message
  - placed after password check per ADR-012 Decision 1
  - avoids leaking account existence
- `app.js` loads `.env` via `dotenv` at startup
- ADR-012 updated with Decision 2 documenting the token storage and expiry rationale
- Also implements the previously skipped E2E test:
  - student can join a joinable consultation in `cancellation.spec.js`

---

## Test Plan

- [x] `npm test`
  - 341 unit + integration tests passing

- [x] `npx playwright test`
  - 16 E2E tests passing
  - previously skipped join test now green

- [x] Sign up as a new student
  - redirected to `/verify-email`
  - email arrives from `"Knock Knock — It's Verification"`
  - enter 6-digit code
  - redirected to login with success message

- [x] Try logging in before verifying
  - blocked with `"has not been verified"` message

- [x] Submit wrong code
  - error shown
  - account not verified

- [x] Submit after expiry
  - expiry error shown

- [x] Resend code 3 times
  - 4th attempt blocked with max attempts error

- [x] Existing seeded users (`pass` / `1234567` etc.) unaffected
  - `email_verified = 1` in all seeds

---

## Closes

- Closes #109