### PR TITLE
feat - add unified activity log, fix logging gaps, and improve admin …

### DIFF
--- a/documentation/ADR's/ADR-012-adminDashboard.md
+++ b/documentation/ADR's/ADR-012-adminDashboard.md
@@ -363,9 +363,41 @@ This increases write complexity and storage requirements.
 
 - Add integration tests for transactional logging.
 - Add unit tests for metadata parsing and dynamic CRUD generation.
-- Prevent audit infrastructure tables from being editable through the dashboard.
-- Add pagination and filtering for large audit datasets.
-- Add administrator-facing audit review pages.
-- Add role-based access validation for admin-only functionality.
+- ~~Prevent audit infrastructure tables from being editable through the dashboard.~~ **Done** — `activity_log`, `affected_records`, `actions`, and `admin_audit_log` added to `READ_ONLY_TABLES` in `admin-controller.js`.
+- ~~Add pagination and filtering for large audit datasets.~~ **Done** — server-side pagination (20 rows/page), full-text search, and category filter chips on the Activity Log page.
+- ~~Add administrator-facing audit review pages.~~ **Done** — see "Delivered: Unified Activity Log UI" below.
+- ~~Add role-based access validation for admin-only functionality.~~ **Done** — `requireRole('admin')` guard on all `/admin/*` routes.
 - Add rollback testing for failed transactional logging scenarios.
 - Ensure composite primary key tables are correctly editable through the dynamic admin interface.
+
+---
+
+## Delivered: Unified Activity Log UI (2026-05-16)
+
+
+
+### What Was Added
+
+A dedicated page at `/admin/activity-log` was built on top of the existing logging schema. The raw `/admin/table/activity_log` route remains accessible for diagnostic use.
+
+**New files:**
+- `src/controllers/admin-activity-log-controller.js` — `showActivityLog` handler with JOIN query, category/search filtering, and server-side pagination.
+- `src/services/activity-log-helpers.js` — maps `action_name` codes to readable event labels, category names, and status values. Single place to update when new action types are added.
+
+**Controller query:** joins `activity_log`, `actions`, `affected_records`, `students`, `staff`, and `admins` to resolve actor name and role alongside each log entry. For `ADMIN_USER_ADD`, `ADMIN_USER_EDIT`, and `ADMIN_USER_DELETE` entries, the detail modal correlates the closest-timestamp row from `admin_audit_log` to show before/after change data without duplicating snapshot columns into `activity_log`.
+
+**Admin sidebar:** the Security section now shows only the "Activity Log" link.
+
+### Logging Gaps Fixed
+
+Three `logActivity` calls were missing and were added:
+
+| Location | Fix |
+|---|---|
+| `auth-controller.js` | Admin login was logged as `USER_LOGIN`. Changed to `ADMIN_LOGIN` so admin sessions are correctly attributed. |
+| `lecturer-consultations-controller.js` | Lecturer-initiated cancellation had no log call. Added `CONSULT_CANCEL_LEC` with the affected consultation ID. |
+| `availability-controller.js` | The new `updateAvailability` handler adds `AVAIL_UPDATE` with the affected availability slot ID. |
+
+### `admin_audit_log` Added to Protected Tables
+
+`admin_audit_log` (introduced in ADR-013) was added to `READ_ONLY_TABLES`. The original ADR-012 protected list (`activity_log`, `affected_records`, `actions`) did not include it.

--- a/src/controllers/admin-activity-log-controller.js
+++ b/src/controllers/admin-activity-log-controller.js
@@ -1,0 +1,138 @@
+const db = require('../../database/db');
+const { getEventLabel, getCategory, getStatus, resolveActorFallback, CATEGORY_ACTIONS } = require('../services/activity-log-helpers');
+
+const PAGE_SIZE = 20;
+const ADMIN_CRUD_ACTIONS = new Set(['ADMIN_USER_ADD', 'ADMIN_USER_EDIT', 'ADMIN_USER_DELETE']);
+
+const fetchAuditData = (userId, createdAt) =>
+  db.prepare(`
+    SELECT old_data, new_data FROM admin_audit_log
+    WHERE admin_id = ?
+    ORDER BY ABS(strftime('%s', timestamp) - strftime('%s', ?))
+    LIMIT 1
+  `).get(userId, createdAt);
+
+const BASE_FROM = `
+  FROM activity_log al
+  JOIN actions a ON al.action_id = a.action_id
+  LEFT JOIN students st  ON al.user_id = CAST(st.student_number AS TEXT)
+  LEFT JOIN staff    stf ON al.user_id = stf.staff_number
+  LEFT JOIN admins   adm ON al.user_id = adm.admin_id
+  LEFT JOIN affected_records ar ON al.log_id = ar.log_id
+`;
+
+const buildWhere = (search, categoryFilter) => {
+  const parts  = [];
+  const params = [];
+
+  if (search) {
+    parts.push(`(
+      COALESCE(st.name, stf.name, adm.name) LIKE ?
+      OR al.user_id LIKE ?
+      OR a.action_name LIKE ?
+      OR a.page_context LIKE ?
+    )`);
+    const like = `%${search}%`;
+    params.push(like, like, like, like);
+  }
+
+  if (categoryFilter && CATEGORY_ACTIONS[categoryFilter]) {
+    const actions = CATEGORY_ACTIONS[categoryFilter];
+    parts.push(`a.action_name IN (${actions.map(() => '?').join(',')})`);
+    params.push(...actions);
+  }
+
+  return { where: parts.length ? `WHERE ${parts.join(' AND ')}` : '', params };
+};
+
+const showActivityLog = (req, res) => {
+  const user           = { id: req.session.userId, name: req.session.userName };
+  const page           = Math.max(1, parseInt(req.query.page) || 1);
+  const offset         = (page - 1) * PAGE_SIZE;
+  const search         = (req.query.search  || '').trim();
+  const categoryFilter = (req.query.category || '').trim();
+
+  const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all().map(r => r.name);
+  const { where, params } = buildWhere(search, categoryFilter);
+
+  try {
+    const totalRows = db.prepare(`
+      SELECT COUNT(DISTINCT al.log_id) as count
+      ${BASE_FROM}
+      ${where}
+    `).get(...params).count;
+
+    const rows = db.prepare(`
+      SELECT
+        al.log_id,
+        al.user_id,
+        al.created_at,
+        a.action_name,
+        a.page_context,
+        a.description,
+        COALESCE(st.name, stf.name, adm.name) AS actor_name,
+        CASE
+          WHEN st.student_number IS NOT NULL THEN 'Student'
+          WHEN stf.staff_number  IS NOT NULL THEN 'Lecturer'
+          WHEN adm.admin_id      IS NOT NULL THEN 'Admin'
+          ELSE 'Unknown'
+        END AS actor_role,
+        GROUP_CONCAT(ar.table_affected || ':' || ar.record_id, ' | ') AS affected_summary
+      ${BASE_FROM}
+      ${where}
+      GROUP BY al.log_id
+      ORDER BY al.created_at DESC
+      LIMIT ? OFFSET ?
+    `).all(...params, PAGE_SIZE, offset);
+
+    const enriched = rows.map(row => {
+      const base = {
+        ...row,
+        eventLabel: getEventLabel(row.action_name),
+        category:   getCategory(row.action_name),
+        status:     getStatus(row.action_name),
+        actorName:  row.actor_name || resolveActorFallback(row.user_id, row.actor_role),
+        old_data:   null,
+        new_data:   null,
+      };
+      if (ADMIN_CRUD_ACTIONS.has(row.action_name)) {
+        const audit = fetchAuditData(row.user_id, row.created_at);
+        if (audit) { base.old_data = audit.old_data; base.new_data = audit.new_data; }
+      }
+      return base;
+    });
+
+    res.render('admin-activity-log', {
+      user,
+      tables,
+      rows: enriched,
+      page,
+      pageSize: PAGE_SIZE,
+      totalPages: Math.max(1, Math.ceil(totalRows / PAGE_SIZE)),
+      totalRows,
+      search,
+      categoryFilter,
+      categories: Object.keys(CATEGORY_ACTIONS),
+      error:   req.query.error   || null,
+      success: req.query.success || null,
+    });
+  } catch (err) {
+    console.error('showActivityLog error:', err);
+    res.render('admin-activity-log', {
+      user,
+      tables,
+      rows: [],
+      page: 1,
+      pageSize: PAGE_SIZE,
+      totalPages: 1,
+      totalRows: 0,
+      search,
+      categoryFilter,
+      categories: Object.keys(CATEGORY_ACTIONS),
+      error:   'Could not load activity log. Please try again.',
+      success: null,
+    });
+  }
+};
+
+module.exports = { showActivityLog };

--- a/src/controllers/admin-controller.js
+++ b/src/controllers/admin-controller.js
@@ -6,7 +6,7 @@ const { logAdminAudit } = require('../services/admin-audit-service')
 
 const PAGE_SIZE = 20
 // tables the admin UI can view but not modify
-const READ_ONLY_TABLES = ['admin_audit_log']
+const READ_ONLY_TABLES = ['admin_audit_log', 'activity_log', 'affected_records', 'actions']
 
 const getAllTables = () =>
   db.prepare('SELECT name FROM sqlite_master WHERE type=\'table\' ORDER BY name').all().map(r => r.name)
@@ -55,6 +55,7 @@ const showAdminDashboard = (req, res) => {
     tables,
     stats,
     activeTable: null,
+    isReadOnly: false,
     columns: [],
     rows: [],
     page: 1,
@@ -83,7 +84,33 @@ const showTable = (req, res) => {
   const inputTypes = getInputTypes(columns)
 
   let totalRows, rows
-  if (search) {
+  if (tableName === 'consultations') {
+    const consultFrom = `
+      FROM consultations c
+      LEFT JOIN staff     stf ON c.lecturer_id = stf.staff_number
+      LEFT JOIN students  st  ON c.organiser   = st.student_number
+    `
+    const courseInfo = `(
+      SELECT cr.course_code || ' — ' || cr.course_name
+      FROM courses cr
+      JOIN staff_courses sc ON sc.course_code = cr.course_code
+      JOIN enrollments   e  ON e.course_code  = cr.course_code
+      WHERE sc.staff_number = c.lecturer_id AND e.student_number = c.organiser
+      LIMIT 1
+    ) AS course_info`
+    const select = `SELECT c.*, c.rowid, stf.name AS lecturer_name, st.name AS organiser_name, ${courseInfo}`
+    if (search) {
+      const like = `%${search}%`
+      const searchWhere = `WHERE (c.consultation_title LIKE ? OR c.consultation_date LIKE ?
+        OR c.lecturer_id LIKE ? OR CAST(c.organiser AS TEXT) LIKE ? OR c.status LIKE ?)`
+      const sp = [like, like, like, like, like]
+      totalRows = db.prepare(`SELECT COUNT(*) as count ${consultFrom} ${searchWhere}`).get(...sp).count
+      rows = db.prepare(`${select} ${consultFrom} ${searchWhere} ORDER BY c.consultation_date DESC LIMIT ? OFFSET ?`).all(...sp, PAGE_SIZE, offset)
+    } else {
+      totalRows = db.prepare(`SELECT COUNT(*) as count FROM consultations`).get().count
+      rows = db.prepare(`${select} ${consultFrom} ORDER BY c.consultation_date DESC LIMIT ? OFFSET ?`).all(PAGE_SIZE, offset)
+    }
+  } else if (search) {
     const { whereClauses, params } = buildSearchQuery(columns, search)
     totalRows = db.prepare(`SELECT COUNT(*) as count FROM "${tableName}" WHERE ${whereClauses}`).get(...params).count
     rows = db.prepare(`SELECT *, rowid as rowid FROM "${tableName}" WHERE ${whereClauses} LIMIT ? OFFSET ?`).all(...params, PAGE_SIZE, offset)
@@ -98,6 +125,7 @@ const showTable = (req, res) => {
     user,
     tables,
     activeTable: tableName,
+    isReadOnly: READ_ONLY_TABLES.includes(tableName),
     columns,
     rows,
     page,

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -42,7 +42,7 @@ const login = async (req, res) => {
     req.session.userId = admin.admin_id
     req.session.userName = admin.name
     req.session.userRole = 'admin'
-    await logActivity(admin.admin_id, ActionTypes.USER_LOGIN, [])
+    await logActivity(admin.admin_id, ActionTypes.ADMIN_LOGIN, [])
     return res.redirect('/admin/dashboard')
   }
   await logActivity(staffStudentNumber || 'UNKNOWN', ActionTypes.AUTH_FAILED_LOGIN, [])

--- a/src/controllers/availability-controller.js
+++ b/src/controllers/availability-controller.js
@@ -90,4 +90,63 @@ const deleteAvailability = async (req, res) => {
   })
 }
 
-module.exports = { showAvailability, saveAvailability, deleteAvailability }
+const updateAvailability = async (req, res) => {
+  const user = { id: req.session.userId, name: req.session.userName, role: req.session.userRole }
+  const { id } = req.params
+  const { day_of_week, start_time, end_time, venue, max_number_of_students, max_booking_min } = req.body
+
+  if (!validateSlotFields({ day_of_week, start_time, end_time, venue, max_number_of_students, max_booking_min })) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: 'All fields are required.', success: null
+    })
+  }
+
+  if (Number(max_number_of_students) < 1 || Number(max_number_of_students) > 10) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: 'Max students must be between 1 and 10.', success: null
+    })
+  }
+
+  if (!isBusinessHours(start_time, end_time)) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: 'Slots must be between 08:00 and 18:00, with end time after start time.', success: null
+    })
+  }
+
+  const slot = db.prepare(
+    'SELECT * FROM lecturer_availability WHERE availability_id = ? AND staff_number = ?'
+  ).get(id, user.id)
+
+  if (!slot) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: 'Slot not found.', success: null
+    })
+  }
+
+  const otherSlots = db.prepare(
+    'SELECT * FROM lecturer_availability WHERE staff_number = ? AND day_of_week = ? AND availability_id != ?'
+  ).all(user.id, day_of_week, id)
+
+  if (isOverlapping(otherSlots, start_time, end_time)) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: 'This slot overlaps with an existing availability slot.', success: null
+    })
+  }
+
+  db.prepare(
+    'UPDATE lecturer_availability SET day_of_week = ?, start_time = ?, end_time = ?, venue = ?, max_number_of_students = ?, max_booking_min = ? WHERE availability_id = ? AND staff_number = ?'
+  ).run(day_of_week, start_time, end_time, venue, Number(max_number_of_students), Number(max_booking_min), id, user.id)
+
+  await logActivity(req.session.userId, ActionTypes.AVAIL_UPDATE, [{ table: 'lecturer_availability', id }])
+  return res.render('availability', {
+    user, availability: getAvailability(user.id),
+    error: null, success: 'Availability slot updated.'
+  })
+}
+
+module.exports = { showAvailability, saveAvailability, deleteAvailability, updateAvailability }

--- a/src/controllers/lecturer-consultations-controller.js
+++ b/src/controllers/lecturer-consultations-controller.js
@@ -1,4 +1,6 @@
 const db = require('../../database/db');
+const { logActivity } = require('../services/logging-service');
+const ActionTypes = require('../services/action-types');
 
 const showLecturerConsultations = (req, res) => {
   const user = {
@@ -53,7 +55,7 @@ const showLecturerConsultations = (req, res) => {
   }
 };
 
-const cancelLecturerConsultation = (req, res) => {
+const cancelLecturerConsultation = async (req, res) => {
   const lecturerId = req.session.userId;
   const { constId } = req.params;
 
@@ -80,6 +82,7 @@ const cancelLecturerConsultation = (req, res) => {
     }
 
     db.prepare(`UPDATE consultations SET status = 'Cancelled' WHERE const_id = ?`).run(constId);
+    await logActivity(lecturerId, ActionTypes.CONSULT_CANCEL_LEC, [{ table: 'consultations', id: constId }]);
 
     return res.redirect('/lecturer/consultations?success=Consultation+cancelled+successfully');
   } catch (err) {

--- a/src/routes/admin-routes.js
+++ b/src/routes/admin-routes.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const { showAdminDashboard, showTable, createRecord, updateRecord, deleteRecord } = require('../controllers/admin-controller');
+const { showActivityLog } = require('../controllers/admin-activity-log-controller');
 const { requireAuth, requireRole } = require('../middleware/auth-middleware');
 
 const router = express.Router();
 const guard = [requireAuth, requireRole('admin')];
 
 router.get('/admin/dashboard', ...guard, showAdminDashboard);
+router.get('/admin/activity-log', ...guard, showActivityLog);
 router.get('/admin/table/:tableName', ...guard, showTable);
 router.post('/admin/table/:tableName/create', ...guard, createRecord);
 router.post('/admin/table/:tableName/:rowId/update', ...guard, updateRecord);

--- a/src/routes/availability-routes.js
+++ b/src/routes/availability-routes.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { showAvailability, saveAvailability, deleteAvailability } = require('../controllers/availability-controller');
+const { showAvailability, saveAvailability, deleteAvailability, updateAvailability } = require('../controllers/availability-controller');
 const { requireAuth, requireRole } = require('../middleware/auth-middleware');
 
 const router = express.Router();
@@ -7,5 +7,6 @@ const router = express.Router();
 router.get('/lecturer/availability', requireAuth, requireRole('lecturer'), showAvailability);
 router.post('/lecturer/availability', requireAuth, requireRole('lecturer'), saveAvailability);
 router.post('/lecturer/availability/:id/delete', requireAuth, requireRole('lecturer'), deleteAvailability);
+router.post('/lecturer/availability/:id/edit', requireAuth, requireRole('lecturer'), updateAvailability);
 
 module.exports = router;

--- a/src/services/activity-log-helpers.js
+++ b/src/services/activity-log-helpers.js
@@ -1,0 +1,73 @@
+const EVENT_LABELS = {
+  USER_LOGIN:              'Logged in',
+  USER_LOGOUT:             'Logged out',
+  USER_SIGNUP:             'Signed up',
+  USER_PASSWORD_CHANGE:    'Changed password',
+  AUTH_FAILED_LOGIN:       'Failed login attempt',
+  CONSULT_CREATE:          'Booked consultation',
+  CONSULT_JOIN:            'Joined consultation',
+  CONSULT_LEAVE:           'Left consultation',
+  CONSULT_CANCEL_ORG:      'Cancelled own consultation',
+  CONSULT_CANCEL_LEC:      'Lecturer cancelled consultation',
+  AVAIL_CREATE:            'Created availability',
+  AVAIL_CANCEL:            'Deleted availability',
+  AVAIL_UPDATE:            'Updated availability',
+  PROFILE_COURSES_UPDATED: 'Updated courses',
+  ADMIN_LOGIN:             'Admin logged in',
+  ADMIN_USER_ADD:          'Added record',
+  ADMIN_USER_EDIT:         'Edited record',
+  ADMIN_USER_DELETE:       'Deleted record',
+};
+
+const CATEGORIES = {
+  USER_LOGIN:              'Auth',
+  USER_LOGOUT:             'Auth',
+  USER_SIGNUP:             'Auth',
+  USER_PASSWORD_CHANGE:    'Auth',
+  AUTH_FAILED_LOGIN:       'Auth',
+  ADMIN_LOGIN:             'Auth',
+  CONSULT_CREATE:          'Booking',
+  CONSULT_JOIN:            'Booking',
+  CONSULT_LEAVE:           'Booking',
+  CONSULT_CANCEL_ORG:      'Cancellation',
+  CONSULT_CANCEL_LEC:      'Cancellation',
+  AVAIL_CREATE:            'Availability',
+  AVAIL_CANCEL:            'Availability',
+  AVAIL_UPDATE:            'Availability',
+  PROFILE_COURSES_UPDATED: 'System',
+  ADMIN_USER_ADD:          'Admin',
+  ADMIN_USER_EDIT:         'Admin',
+  ADMIN_USER_DELETE:       'Admin',
+};
+
+const STATUSES = {
+  AUTH_FAILED_LOGIN:  'Failed',
+  CONSULT_CANCEL_ORG: 'Cancelled',
+  CONSULT_CANCEL_LEC: 'Cancelled',
+  AVAIL_CANCEL:       'Deleted',
+  ADMIN_USER_DELETE:  'Deleted',
+  AVAIL_UPDATE:       'Updated',
+  ADMIN_USER_EDIT:    'Updated',
+};
+
+const CATEGORY_ACTIONS = {
+  Auth:         ['USER_LOGIN', 'USER_LOGOUT', 'USER_SIGNUP', 'USER_PASSWORD_CHANGE', 'AUTH_FAILED_LOGIN', 'ADMIN_LOGIN'],
+  Booking:      ['CONSULT_CREATE', 'CONSULT_JOIN', 'CONSULT_LEAVE'],
+  Cancellation: ['CONSULT_CANCEL_ORG', 'CONSULT_CANCEL_LEC'],
+  Availability: ['AVAIL_CREATE', 'AVAIL_CANCEL', 'AVAIL_UPDATE'],
+  Admin:        ['ADMIN_USER_ADD', 'ADMIN_USER_EDIT', 'ADMIN_USER_DELETE'],
+  System:       ['PROFILE_COURSES_UPDATED'],
+};
+
+const getEventLabel = (actionName) => EVENT_LABELS[actionName] || actionName;
+const getCategory   = (actionName) => CATEGORIES[actionName]  || 'System';
+const getStatus     = (actionName) => STATUSES[actionName]    || 'Success';
+
+const resolveActorFallback = (userId, actorRole) => {
+  if (actorRole === 'Student')  return 'Unknown Student';
+  if (actorRole === 'Lecturer') return 'Unknown Lecturer';
+  if (actorRole === 'Admin')    return 'Unknown Admin';
+  return userId || 'System';
+};
+
+module.exports = { getEventLabel, getCategory, getStatus, resolveActorFallback, CATEGORY_ACTIONS };

--- a/src/views/admin-activity-log.html
+++ b/src/views/admin-activity-log.html
@@ -1,0 +1,411 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Activity Log — KnockKnock.prof</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="/css/theme.css">
+  <style>
+    .adm-brand-orange { color: #f57c00; }
+
+    .adm-btn-logout {
+      background: transparent; color: #064735;
+      border: 1.5px solid #064735; border-radius: 6px;
+      padding: 5px 16px; font-weight: 600; font-size: 0.875rem;
+      transition: 0.2s ease; cursor: pointer;
+    }
+    .adm-btn-logout:hover { background: #fff0d9; border-color: #f57c00; color: #f57c00; }
+
+    .sidebar .table-link         { color: #064735; }
+    .sidebar .table-link:hover   { background: #dff5e3; color: #064735; }
+    .sidebar .table-link.active  {
+      background: #064735; color: #fff; font-weight: 600;
+      border-left: 3px solid #f57c00; padding-left: 11px; position: relative;
+    }
+    .sidebar .table-link.active::after {
+      content: ''; position: absolute; right: 10px; top: 50%;
+      transform: translateY(-50%); width: 6px; height: 6px;
+      border-radius: 50%; background: #f57c00;
+    }
+    .adm-nav-label {
+      font-size: 0.63rem; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #667085;
+      margin: 0.85rem 0 0.25rem; padding: 0 2px; display: block;
+    }
+
+    .adm-main { background: #fbf7ef; }
+    .adm-heading-green { color: #064735; }
+
+    /* ── Category chips ── */
+    .cat-chip {
+      display: inline-block; padding: 2px 10px; border-radius: 999px;
+      font-size: 0.72rem; font-weight: 600; white-space: nowrap;
+    }
+    .cat-Auth         { background: #e0f2fe; color: #0369a1; }
+    .cat-Booking      { background: #dcfce7; color: #166534; }
+    .cat-Cancellation { background: #fee2e2; color: #991b1b; }
+    .cat-Availability { background: #fef9c3; color: #713f12; }
+    .cat-Admin        { background: #f3e8ff; color: #6b21a8; }
+    .cat-System       { background: #f1f5f9; color: #475569; }
+
+    /* ── Status chips ── */
+    .status-chip {
+      display: inline-block; padding: 2px 10px; border-radius: 999px;
+      font-size: 0.72rem; font-weight: 600; white-space: nowrap;
+    }
+    .status-Success   { background: #dcfce7; color: #166534; }
+    .status-Failed    { background: #fee2e2; color: #991b1b; }
+    .status-Cancelled { background: #fef3c7; color: #92400e; }
+    .status-Deleted   { background: #fee2e2; color: #991b1b; }
+    .status-Updated   { background: #e0f2fe; color: #0369a1; }
+
+    /* ── Filter buttons ── */
+    .filter-btn {
+      padding: 4px 14px; border-radius: 999px; font-size: 0.8rem;
+      font-weight: 600; border: 1.5px solid #064735; color: #064735;
+      background: transparent; text-decoration: none; transition: 0.2s ease;
+      display: inline-block;
+    }
+    .filter-btn:hover, .filter-btn.active {
+      background: #064735; color: #fff; border-color: #064735;
+    }
+
+    /* ── Main table: allow truncation for space ── */
+    .log-table td, .log-table th {
+      white-space: nowrap; max-width: 200px;
+      overflow: hidden; text-overflow: ellipsis;
+    }
+
+    /* ── Modal detail table: never truncate ── */
+    .modal-detail-table td,
+    .modal-detail-table th {
+      white-space: normal !important;
+      max-width: none !important;
+      overflow: visible !important;
+      text-overflow: unset !important;
+      word-break: break-word;
+      vertical-align: top;
+    }
+  </style>
+</head>
+<body>
+
+  <header class="topbar p-3 d-flex justify-content-between align-items-center">
+    <a class="navbar-brand d-flex align-items-center gap-2" href="/">
+      <img src="/images/door-logo-transparent.svg" alt="KnockKnock.prof door logo" class="kk-door-logo">
+      <div>
+        <div class="kk-brand-name">KnockKnock<span class="adm-brand-orange">.prof</span></div>
+        <div class="kk-brand-tagline">Open the door to better consultations</div>
+      </div>
+    </a>
+    <div class="d-flex align-items-center gap-3">
+      <span class="text-muted small"><%= user.name %> (Admin)</span>
+      <form action="/logout" method="POST" class="d-inline">
+        <button type="submit" class="adm-btn-logout">Logout</button>
+      </form>
+    </div>
+  </header>
+
+  <div class="d-flex" style="min-height: calc(100vh - 62px)">
+
+    <!-- Sidebar -->
+    <div class="sidebar p-3" style="width: 220px; min-width: 220px;">
+      <a href="/admin/dashboard" class="table-link d-flex align-items-center gap-2 mb-1">
+        <i class="bi bi-house-door"></i> Home
+      </a>
+
+      <span class="adm-nav-label">Users</span>
+      <a href="/admin/table/admins"    class="table-link"><i class="bi bi-shield-check me-1"></i>Admins</a>
+      <a href="/admin/table/students"  class="table-link"><i class="bi bi-people me-1"></i>Students</a>
+      <a href="/admin/table/staff"     class="table-link"><i class="bi bi-person-badge me-1"></i>Staff</a>
+
+      <span class="adm-nav-label">Academic</span>
+      <a href="/admin/table/courses"       class="table-link"><i class="bi bi-journal-text me-1"></i>Courses</a>
+      <a href="/admin/table/degrees"       class="table-link"><i class="bi bi-mortarboard me-1"></i>Degrees</a>
+      <a href="/admin/table/departments"   class="table-link"><i class="bi bi-building me-1"></i>Departments</a>
+      <a href="/admin/table/enrollments"   class="table-link"><i class="bi bi-card-list me-1"></i>Enrollments</a>
+      <a href="/admin/table/staff_courses" class="table-link"><i class="bi bi-link-45deg me-1"></i>Staff Courses</a>
+
+      <span class="adm-nav-label">Consultations</span>
+      <a href="/admin/table/consultations"          class="table-link"><i class="bi bi-calendar-event me-1"></i>Consultations</a>
+      <a href="/admin/table/consultation_attendees" class="table-link"><i class="bi bi-person-lines-fill me-1"></i>Attendees</a>
+
+      <span class="adm-nav-label">Availability</span>
+      <a href="/admin/table/lecturer_availability" class="table-link"><i class="bi bi-clock-history me-1"></i>Lecturer Availability</a>
+
+      <span class="adm-nav-label">Security</span>
+      <a href="/admin/activity-log" class="table-link active"><i class="bi bi-journal-check me-1"></i>Activity Log</a>
+    </div>
+
+    <!-- Main -->
+    <div class="flex-grow-1 p-4 adm-main" style="min-width:0;">
+
+      <div class="mb-3">
+        <h3 class="adm-heading-green fw-bold mb-1">Activity Log</h3>
+        <p class="text-muted small mb-0">System-wide record of all user actions across students, lecturers, and administrators.</p>
+      </div>
+
+      <% if (error) { %>
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+          <%= error %>
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+      <% } %>
+
+      <!-- Search + Filter bar -->
+      <div class="card p-3 mb-3">
+        <form method="GET" action="/admin/activity-log" class="d-flex flex-wrap gap-2 align-items-center">
+          <input type="text" name="search" class="form-control form-control-sm" style="max-width:260px;"
+            placeholder="Search user, action, page..." value="<%= search %>">
+          <input type="hidden" name="category" value="<%= categoryFilter %>">
+          <button type="submit" class="btn btn-sm btn-primary">Search</button>
+          <% if (search || categoryFilter) { %>
+            <a href="/admin/activity-log" class="btn btn-sm btn-outline-secondary">Clear</a>
+          <% } %>
+        </form>
+
+        <div class="d-flex flex-wrap gap-2 mt-2">
+          <a href="/admin/activity-log<%= search ? '?search=' + encodeURIComponent(search) : '' %>"
+             class="filter-btn <%= !categoryFilter ? 'active' : '' %>">All</a>
+          <% categories.forEach(cat => { %>
+            <a href="/admin/activity-log?category=<%= encodeURIComponent(cat) %><%= search ? '&search=' + encodeURIComponent(search) : '' %>"
+               class="filter-btn <%= categoryFilter === cat ? 'active' : '' %>"><%= cat %></a>
+          <% }); %>
+        </div>
+      </div>
+
+      <!-- Results summary -->
+      <div class="text-muted small mb-2">
+        <% if (totalRows === 0) { %>
+          No entries found
+        <% } else { %>
+          Showing <%= (page - 1) * pageSize + 1 %>–<%= Math.min(page * pageSize, totalRows) %> of <%= totalRows %> entries
+        <% } %>
+        <% if (categoryFilter) { %> &mdash; filtered by <strong><%= categoryFilter %></strong><% } %>
+        <% if (search) { %> &mdash; matching <strong>"<%= search %>"</strong><% } %>
+      </div>
+
+      <% if (rows.length === 0) { %>
+        <div class="card p-5 text-center text-muted">
+          <i class="bi bi-journal-x fs-1 mb-2"></i>
+          <p class="mb-0">No activity log entries found<% if (search || categoryFilter) { %> for the current filters<% } %>.</p>
+        </div>
+      <% } else { %>
+
+      <div class="card p-0 overflow-hidden">
+        <div class="table-responsive">
+          <table class="table table-hover align-middle mb-0 log-table">
+            <caption class="visually-hidden">System activity log</caption>
+            <thead style="background:#dff5e3;">
+              <tr>
+                <th class="ps-3 py-2" style="color:#064735;font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Timestamp</th>
+                <th class="py-2"      style="color:#064735;font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">User</th>
+                <th class="py-2"      style="color:#064735;font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Role</th>
+                <th class="py-2"      style="color:#064735;font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Event</th>
+                <th class="py-2"      style="color:#064735;font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Detail</th>
+                <th class="py-2"      style="color:#064735;font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Category</th>
+                <th class="py-2"      style="color:#064735;font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Status</th>
+                <th class="py-2 pe-3" style="color:#064735;font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% rows.forEach(row => { %>
+                <tr>
+                  <td class="ps-3 text-nowrap" style="font-size:0.82rem;color:#475569;">
+                    <%= row.created_at ? row.created_at.replace('T', ' ').substring(0, 16) : '—' %>
+                  </td>
+                  <td class="fw-semibold" style="font-size:0.88rem;"><%= row.actorName %></td>
+                  <td style="font-size:0.82rem;"><%= row.actor_role %></td>
+                  <td style="font-size:0.88rem;"><%= row.eventLabel %></td>
+                  <td class="text-muted" style="font-size:0.8rem;"><%= row.description %></td>
+                  <td><span class="cat-chip cat-<%= row.category %>"><%= row.category %></span></td>
+                  <td><span class="status-chip status-<%= row.status %>"><%= row.status %></span></td>
+                  <td class="pe-3">
+                    <button type="button" class="btn btn-outline-secondary btn-sm"
+                      data-bs-toggle="modal"
+                      data-bs-target="#detailModal"
+                      data-log-id="<%= row.log_id %>"
+                      data-user-id="<%= row.user_id %>"
+                      data-actor-name="<%= row.actorName %>"
+                      data-actor-role="<%= row.actor_role %>"
+                      data-timestamp="<%= row.created_at || '' %>"
+                      data-action-name="<%= row.action_name %>"
+                      data-event-label="<%= row.eventLabel %>"
+                      data-page-context="<%= row.page_context %>"
+                      data-description="<%= row.description %>"
+                      data-category="<%= row.category %>"
+                      data-status="<%= row.status %>"
+                      data-affected="<%= row.affected_summary || '' %>"
+                      data-old-data="<%= row.old_data || '' %>"
+                      data-new-data="<%= row.new_data || '' %>">
+                      View
+                    </button>
+                  </td>
+                </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- Pagination -->
+      <% if (totalPages > 1) { %>
+        <nav aria-label="Activity log pages" class="mt-3">
+          <ul class="pagination pagination-sm justify-content-end mb-0">
+            <li class="page-item <%= page <= 1 ? 'disabled' : '' %>">
+              <a class="page-link" href="/admin/activity-log?page=<%= page - 1 %><%= search ? '&search=' + encodeURIComponent(search) : '' %><%= categoryFilter ? '&category=' + encodeURIComponent(categoryFilter) : '' %>">Previous</a>
+            </li>
+            <% for (let p = Math.max(1, page - 2); p <= Math.min(totalPages, page + 2); p++) { %>
+              <li class="page-item <%= p === page ? 'active' : '' %>">
+                <a class="page-link" href="/admin/activity-log?page=<%= p %><%= search ? '&search=' + encodeURIComponent(search) : '' %><%= categoryFilter ? '&category=' + encodeURIComponent(categoryFilter) : '' %>"><%= p %></a>
+              </li>
+            <% } %>
+            <li class="page-item <%= page >= totalPages ? 'disabled' : '' %>">
+              <a class="page-link" href="/admin/activity-log?page=<%= page + 1 %><%= search ? '&search=' + encodeURIComponent(search) : '' %><%= categoryFilter ? '&category=' + encodeURIComponent(categoryFilter) : '' %>">Next</a>
+            </li>
+          </ul>
+        </nav>
+      <% } %>
+
+      <% } %>
+    </div>
+  </div>
+
+  <!-- Detail Modal -->
+  <div class="modal fade" id="detailModal" tabindex="-1" aria-labelledby="detailModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header" style="background:#dff5e3;">
+          <h5 class="modal-title fw-bold" id="detailModalLabel" style="color:#064735;">Log Entry Detail</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+
+          <h6 class="fw-semibold text-muted mb-2" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Summary</h6>
+          <table class="table table-sm table-bordered mb-4 modal-detail-table" style="font-size:0.88rem;">
+            <tbody>
+              <tr><th style="width:160px;white-space:nowrap;">Log ID</th>       <td id="d-log-id"></td></tr>
+              <tr><th style="white-space:nowrap;">Timestamp</th>                <td id="d-timestamp"></td></tr>
+              <tr><th style="white-space:nowrap;">User</th>                     <td id="d-actor-name"></td></tr>
+              <tr><th style="white-space:nowrap;">Actor ID</th>                 <td id="d-user-id" style="font-family:monospace;font-size:0.82rem;"></td></tr>
+              <tr><th style="white-space:nowrap;">Role</th>                     <td id="d-actor-role"></td></tr>
+              <tr><th style="white-space:nowrap;">Event</th>                    <td id="d-event-label"></td></tr>
+              <tr><th style="white-space:nowrap;">Action Code</th>              <td id="d-action-name" style="font-family:monospace;font-size:0.82rem;"></td></tr>
+              <tr><th style="white-space:nowrap;">Category</th>                 <td><span id="d-category-chip" class="cat-chip"></span></td></tr>
+              <tr><th style="white-space:nowrap;">Status</th>                   <td><span id="d-status-chip" class="status-chip"></span></td></tr>
+              <tr><th style="white-space:nowrap;">Page / Context</th>           <td id="d-page-context"></td></tr>
+              <tr><th style="white-space:nowrap;">Full Detail</th>              <td id="d-description"></td></tr>
+            </tbody>
+          </table>
+
+          <h6 class="fw-semibold text-muted mb-2" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Affected Records</h6>
+          <div id="d-affected" class="mb-4" style="font-size:0.88rem;"></div>
+
+          <div id="d-change-section">
+            <h6 class="fw-semibold text-muted mb-2" style="font-size:0.72rem;text-transform:uppercase;letter-spacing:.06em;">Change Data</h6>
+            <table class="table table-sm table-bordered mb-0 modal-detail-table" style="font-size:0.88rem;">
+              <tbody>
+                <tr id="d-old-row">
+                  <th style="width:160px;white-space:nowrap;vertical-align:top;">Old Data</th>
+                  <td><pre id="d-old-data" style="font-size:0.78rem;max-height:200px;overflow:auto;margin:0;white-space:pre-wrap;word-break:break-all;"></pre></td>
+                </tr>
+                <tr id="d-new-row">
+                  <th style="white-space:nowrap;vertical-align:top;">New Data</th>
+                  <td><pre id="d-new-data" style="font-size:0.78rem;max-height:200px;overflow:auto;margin:0;white-space:pre-wrap;word-break:break-all;"></pre></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = (value !== null && value !== undefined && value !== '') ? value : '—';
+  }
+
+  function formatJson(raw) {
+    if (!raw) return null;
+    try { return JSON.stringify(JSON.parse(raw), null, 2); }
+    catch { return raw; }
+  }
+
+  document.getElementById('detailModal').addEventListener('show.bs.modal', function (event) {
+    const btn = event.relatedTarget;
+
+    setText('d-log-id',       btn.dataset.logId);
+    setText('d-timestamp',    btn.dataset.timestamp);
+    setText('d-actor-name',   btn.dataset.actorName);
+    setText('d-user-id',      btn.dataset.userId);
+    setText('d-actor-role',   btn.dataset.actorRole);
+    setText('d-event-label',  btn.dataset.eventLabel);
+    setText('d-action-name',  btn.dataset.actionName);
+    setText('d-page-context', btn.dataset.pageContext);
+    setText('d-description',  btn.dataset.description);
+
+    const category = btn.dataset.category || '';
+    const catChip  = document.getElementById('d-category-chip');
+    catChip.textContent = category;
+    catChip.className   = 'cat-chip cat-' + category;
+
+    const status   = btn.dataset.status || '';
+    const statChip = document.getElementById('d-status-chip');
+    statChip.textContent = status;
+    statChip.className   = 'status-chip status-' + status;
+
+    // Affected records
+    const affectedEl = document.getElementById('d-affected');
+    const affected   = btn.dataset.affected || '';
+    if (!affected) {
+      affectedEl.textContent = 'No affected records recorded.';
+    } else {
+      const ul = document.createElement('ul');
+      ul.className = 'mb-0 ps-3';
+      ul.style.fontSize = '0.88rem';
+      affected.split(' | ').forEach(entry => {
+        const li = document.createElement('li');
+        const parts = entry.split(':');
+        li.textContent = parts.length === 2
+          ? parts[0].trim() + ' — record #' + parts[1].trim()
+          : entry;
+        ul.appendChild(li);
+      });
+      affectedEl.replaceChildren(ul);
+    }
+
+    // Old / new data (admin CRUD only)
+    const oldRaw = btn.dataset.oldData || '';
+    const newRaw = btn.dataset.newData || '';
+    const hasChange = oldRaw || newRaw;
+
+    document.getElementById('d-change-section').style.display = hasChange ? '' : 'none';
+
+    if (hasChange) {
+      const oldFormatted = formatJson(oldRaw);
+      const newFormatted = formatJson(newRaw);
+
+      const oldPre = document.getElementById('d-old-data');
+      const oldRow = document.getElementById('d-old-row');
+      if (oldFormatted) { oldPre.textContent = oldFormatted; oldRow.style.display = ''; }
+      else              { oldRow.style.display = 'none'; }
+
+      const newPre = document.getElementById('d-new-data');
+      const newRow = document.getElementById('d-new-row');
+      if (newFormatted) { newPre.textContent = newFormatted; newRow.style.display = ''; }
+      else              { newRow.style.display = 'none'; }
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/src/views/admin-dashboard.html
+++ b/src/views/admin-dashboard.html
@@ -183,7 +183,7 @@ function formatCol(name) {
       <a href="/admin/table/lecturer_availability" class="table-link <%= activeTable === 'lecturer_availability' ? 'active' : '' %>"><i class="bi bi-clock-history me-1"></i>Lecturer Availability</a>
 
       <span class="adm-nav-label">Security</span>
-      <a href="/admin/table/admin_audit_log" class="table-link <%= activeTable === 'admin_audit_log' ? 'active' : '' %>"><i class="bi bi-shield-lock me-1"></i>Audit Log</a>
+      <a href="/admin/activity-log" class="table-link"><i class="bi bi-journal-check me-1"></i>Activity Log</a>
     </div>
 
     <!-- Main -->
@@ -262,7 +262,7 @@ function formatCol(name) {
                         data-row="<%= JSON.stringify(row) %>"
                         data-rowid="<%= row.rowid %>">Edit</button>
                       <button class="btn btn-outline-danger btn-sm delete-btn"
-                        data-rowid="<%= row.rowid %>">Del</button>
+                        data-rowid="<%= row.rowid %>">Delete</button>
                     </td>
                   </tr>
                 <% }); %>
@@ -280,7 +280,7 @@ function formatCol(name) {
         </div>
 
         <% } else { %>
-        <% const isReadOnlyTable = activeTable === 'admin_audit_log'; %>
+        <% const isReadOnlyTable = isReadOnly; %>
 
         <!-- ── Generic table ── -->
         <div class="d-flex justify-content-between align-items-center mb-3">
@@ -683,17 +683,18 @@ function formatCol(name) {
         const row = JSON.parse(btn.dataset.row);
         const fields = [
           ['ID',              row.const_id],
+          ['Status',          row.status],
+          ['Course',          row.course_info || '—'],
           ['Title',           row.consultation_title],
           ['Description',     row.consultation_description || '—'],
           ['Date',            row.consultation_date],
           ['Time',            row.consultation_time],
           ['Duration',        row.duration_min != null ? row.duration_min + ' min' : '—'],
           ['Venue',           row.venue],
-          ['Status',          row.status],
           ['Max Students',    row.max_number_of_students],
           ['Allow Join',      row.allow_join ? 'Yes' : 'No'],
-          ['Lecturer ID',     row.lecturer_id],
-          ['Organiser',       row.organiser],
+          ['Lecturer',        row.lecturer_name ? row.lecturer_name + ' (' + row.lecturer_id + ')' : row.lecturer_id],
+          ['Organiser',       row.organiser_name ? row.organiser_name + ' (' + row.organiser + ')' : row.organiser],
           ['Availability ID', row.availability_id],
         ];
         document.getElementById('viewDetailsBody').innerHTML =

--- a/src/views/availability.html
+++ b/src/views/availability.html
@@ -143,7 +143,16 @@
                         <td><%= slot.venue %></td>
                         <td><%= slot.max_number_of_students %></td>
                         <td><%= slot.max_booking_min %></td>
-                        <td class="pe-3">
+                        <td class="pe-3 text-nowrap">
+                          <button type="button" class="btn btn-outline-secondary btn-sm me-1"
+                            data-bs-toggle="modal" data-bs-target="#editSlotModal"
+                            data-id="<%= slot.availability_id %>"
+                            data-day="<%= slot.day_of_week %>"
+                            data-start="<%= slot.start_time %>"
+                            data-end="<%= slot.end_time %>"
+                            data-venue="<%= slot.venue %>"
+                            data-students="<%= slot.max_number_of_students %>"
+                            data-duration="<%= slot.max_booking_min %>">Edit</button>
                           <form action="/lecturer/availability/<%= slot.availability_id %>/delete" method="POST" class="d-inline">
                             <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>
                           </form>
@@ -162,5 +171,77 @@
   </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+<!-- Edit Slot Modal -->
+<div class="modal fade" id="editSlotModal" tabindex="-1" aria-labelledby="editSlotModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="editSlotForm" method="POST">
+        <div class="modal-header">
+          <h5 class="modal-title" id="editSlotModalLabel">Edit Availability Slot</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+
+          <div class="mb-3">
+            <label for="edit_day_of_week" class="form-label fw-semibold">Day</label>
+            <select class="form-select" id="edit_day_of_week" name="day_of_week" required>
+              <option value="Mon">Monday</option>
+              <option value="Tue">Tuesday</option>
+              <option value="Wed">Wednesday</option>
+              <option value="Thu">Thursday</option>
+              <option value="Fri">Friday</option>
+            </select>
+          </div>
+
+          <div class="row g-3 mb-3">
+            <div class="col-6">
+              <label for="edit_start_time" class="form-label fw-semibold">Start Time</label>
+              <input type="time" class="form-control" id="edit_start_time" name="start_time" min="08:00" max="18:00" required>
+            </div>
+            <div class="col-6">
+              <label for="edit_end_time" class="form-label fw-semibold">End Time</label>
+              <input type="time" class="form-control" id="edit_end_time" name="end_time" min="08:00" max="18:00" required>
+            </div>
+          </div>
+
+          <div class="mb-3">
+            <label for="edit_max_booking_min" class="form-label fw-semibold">Max Consultation Duration (min)</label>
+            <input type="number" class="form-control" id="edit_max_booking_min" name="max_booking_min" min="15" max="480" required>
+          </div>
+
+          <div class="mb-3">
+            <label for="edit_venue" class="form-label fw-semibold">Venue</label>
+            <input type="text" class="form-control" id="edit_venue" name="venue" required>
+          </div>
+
+          <div class="mb-3">
+            <label for="edit_max_number_of_students" class="form-label fw-semibold">Max Students per Slot</label>
+            <input type="number" class="form-control" id="edit_max_number_of_students" name="max_number_of_students" min="1" max="10" required>
+          </div>
+
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary">Save Changes</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  document.getElementById('editSlotModal').addEventListener('show.bs.modal', function (event) {
+    const btn = event.relatedTarget;
+    document.getElementById('editSlotForm').action = '/lecturer/availability/' + btn.dataset.id + '/edit';
+    document.getElementById('edit_day_of_week').value = btn.dataset.day;
+    document.getElementById('edit_start_time').value = btn.dataset.start;
+    document.getElementById('edit_end_time').value = btn.dataset.end;
+    document.getElementById('edit_venue').value = btn.dataset.venue;
+    document.getElementById('edit_max_booking_min').value = btn.dataset.duration;
+    document.getElementById('edit_max_number_of_students').value = btn.dataset.students;
+  });
+</script>
+
 </body>
 </html>

--- a/tests/integration/adminActivityLog.test.js
+++ b/tests/integration/adminActivityLog.test.js
@@ -7,7 +7,7 @@ const adminAgent = () => {
   return agent
     .post('/login')
     .type('form')
-    .send({ staffStudentNumber: 'ADMIN001', password: 'admin' })
+    .send({ staffStudentNumber: 'ADMIN001', password: 'Password01' })
     .then(() => agent);
 };
 
@@ -20,14 +20,14 @@ describe('GET /admin/activity-log', () => {
 
   test('returns 403 when authenticated as a student', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/admin/activity-log');
     expect(res.status).toBe(403);
   });
 
   test('returns 403 when authenticated as a lecturer', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: 'A000356', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: 'A000356', password: 'Password01' });
     const res = await agent.get('/admin/activity-log');
     expect(res.status).toBe(403);
   });

--- a/tests/integration/adminActivityLog.test.js
+++ b/tests/integration/adminActivityLog.test.js
@@ -1,0 +1,117 @@
+/* eslint-env jest */
+const request = require('supertest');
+const app = require('../../app');
+
+const adminAgent = () => {
+  const agent = request.agent(app);
+  return agent
+    .post('/login')
+    .type('form')
+    .send({ staffStudentNumber: 'ADMIN001', password: 'admin' })
+    .then(() => agent);
+};
+
+describe('GET /admin/activity-log', () => {
+  test('redirects to /login when not authenticated', async () => {
+    const res = await request(app).get('/admin/activity-log');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('returns 403 when authenticated as a student', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    const res = await agent.get('/admin/activity-log');
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 403 when authenticated as a lecturer', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: 'A000356', password: 'pass' });
+    const res = await agent.get('/admin/activity-log');
+    expect(res.status).toBe(403);
+  });
+
+  test('renders the Activity Log page with correct heading for admin', async () => {
+    const agent = await adminAgent();
+    const res = await agent.get('/admin/activity-log');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Activity Log');
+  });
+
+  test('page includes column headers: User, Role, Event, Category, Status', async () => {
+    const agent = await adminAgent();
+    const res = await agent.get('/admin/activity-log');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('User');
+    expect(res.text).toContain('Role');
+    expect(res.text).toContain('Event');
+    expect(res.text).toContain('Category');
+    expect(res.text).toContain('Status');
+  });
+
+  test('page includes a View button when log entries exist', async () => {
+    const agent = await adminAgent();
+    const res = await agent.get('/admin/activity-log');
+    expect(res.status).toBe(200);
+    if (res.text.includes('No activity log entries')) return;
+    expect(res.text).toContain('View');
+  });
+
+  test('page includes category filter buttons', async () => {
+    const agent = await adminAgent();
+    const res = await agent.get('/admin/activity-log');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Auth');
+    expect(res.text).toContain('Booking');
+    expect(res.text).toContain('Availability');
+  });
+
+  test('page shows empty state message when no entries match', async () => {
+    const agent = await adminAgent();
+    const res = await agent.get('/admin/activity-log?search=zzznomatch999');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('No activity log entries found');
+  });
+
+  test('search parameter is reflected in the search input', async () => {
+    const agent = await adminAgent();
+    const res = await agent.get('/admin/activity-log?search=login');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('login');
+  });
+
+  test('category filter parameter is applied without error', async () => {
+    const agent = await adminAgent();
+    const res = await agent.get('/admin/activity-log?category=Auth');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Activity Log');
+  });
+
+  test('activity_log table remains accessible as a read-only raw table', async () => {
+    const agent = await adminAgent();
+    const res = await agent.get('/admin/table/activity_log');
+    expect(res.status).toBe(200);
+  });
+
+  test('POST to create a record in activity_log is blocked as read-only', async () => {
+    const agent = await adminAgent();
+    const res = await agent.post('/admin/table/activity_log/create').type('form').send({});
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error=This+table+is+read-only');
+  });
+
+  test('POST to create a record in affected_records is blocked as read-only', async () => {
+    const agent = await adminAgent();
+    const res = await agent.post('/admin/table/affected_records/create').type('form').send({});
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error=This+table+is+read-only');
+  });
+
+  test('POST to create a record in actions is blocked as read-only', async () => {
+    const agent = await adminAgent();
+    const res = await agent.post('/admin/table/actions/create').type('form').send({});
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error=This+table+is+read-only');
+  });
+});

--- a/tests/integration/consultationBooking.test.js
+++ b/tests/integration/consultationBooking.test.js
@@ -24,7 +24,7 @@ const getNextWeekday = (dowTarget) => {
 describe('GET /consultations/new', () => {
   test('redirects to dashboard when staffNumber param is missing', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/consultations/new?availabilityId=1&date=2026-05-12');
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('/student/dashboard');
@@ -32,7 +32,7 @@ describe('GET /consultations/new', () => {
 
   test('redirects when student is not enrolled in any course taught by that lecturer', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const date = getNextWeekday('Mon');
     const res = await agent.get(`/consultations/new?staffNumber=STAFF_NOBODY&availabilityId=1&date=${date}`);
     expect(res.status).toBe(302);
@@ -41,7 +41,7 @@ describe('GET /consultations/new', () => {
 
   test('renders booking page for enrolled student with valid params', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const date = getNextWeekday('Mon');
     const res = await agent.get(`/consultations/new?staffNumber=A000356&availabilityId=1&date=${date}`);
     expect(res.status).toBe(200);
@@ -76,7 +76,7 @@ describe('POST /consultations/new', () => {
 
   test('creates consultation and attendee row on valid booking', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await bookSlot(agent, { title: `Valid Booking ${testTag}`, allow_join: '1' });
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('/student/dashboard');
@@ -95,7 +95,7 @@ describe('POST /consultations/new', () => {
 
   test('stores allow_join=0 when checkbox is not sent', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const body = {
       staff_number: 'A000356', availability_id: '3', date,
       start_time: '10:15', duration_min: '15', title: `No Join ${testTag}`,
@@ -110,7 +110,7 @@ describe('POST /consultations/new', () => {
 
   test('rejects booking outside the availability window', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await bookSlot(agent, { start_time: '08:00', title: 'Outside window booking' });
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('error');
@@ -118,7 +118,7 @@ describe('POST /consultations/new', () => {
 
   test('rejects booking that overlaps an existing non-joinable consultation', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
 
     const firstBody = {
       staff_number: 'A000356', availability_id: '3', date,
@@ -148,7 +148,7 @@ describe('weather on booking page', () => {
   test('booking page renders with status 200 when weather service throws', async () => {
     getWitsWeather.mockRejectedValueOnce(new Error('Weather service unavailable'));
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const date = getNextWeekday('Mon');
     const res = await agent.get(`/consultations/new?staffNumber=A000356&availabilityId=1&date=${date}`);
     expect(res.status).toBe(200);
@@ -161,7 +161,7 @@ describe('weather on booking page', () => {
       [date]: { condition: 'rainy', icon: '🌧️', maxTemp: 18, message: 'Rain expected' },
     });
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get(`/consultations/new?staffNumber=A000356&availabilityId=1&date=${date}`);
     expect(res.status).toBe(200);
     expect(res.text).toContain('Rain is expected');

--- a/tests/integration/consultationJoin.test.js
+++ b/tests/integration/consultationJoin.test.js
@@ -37,7 +37,7 @@ describe('POST /consultations/:constId/join', () => {
 
   test('rejects join when student is already an attendee', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.post(`/consultations/${constId}/join`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('error');
@@ -47,7 +47,7 @@ describe('POST /consultations/:constId/join', () => {
     db.prepare('DELETE FROM consultation_attendees WHERE const_id = ? AND student_number = ?').run(constId, 1234567);
 
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.post(`/consultations/${constId}/join`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('/student/dashboard');
@@ -70,7 +70,7 @@ describe('POST /consultations/:constId/join', () => {
     // capacity check fires before already-attending check → correct rejection reason
 
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.post(`/consultations/${constId}/join`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('error');

--- a/tests/integration/courseDetail.test.js
+++ b/tests/integration/courseDetail.test.js
@@ -12,7 +12,7 @@ describe('GET /courses/:courseCode', () => {
 
   test('renders course detail page for enrolled student', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/courses/ELEN4010');
     expect(res.status).toBe(200);
     expect(res.text).toContain('ELEN4010');
@@ -21,7 +21,7 @@ describe('GET /courses/:courseCode', () => {
 
   test('shows lecturer names for enrolled course', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/courses/ELEN4010');
     expect(res.status).toBe(200);
     expect(res.text).toContain('Clark Kent');
@@ -29,7 +29,7 @@ describe('GET /courses/:courseCode', () => {
 
   test('redirects non-enrolled student to dashboard with error', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/courses/MECN2026');
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('/student/dashboard');
@@ -38,7 +38,7 @@ describe('GET /courses/:courseCode', () => {
 
   test('renders course detail page for enrolled course with no base-seed lecturers', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/courses/ELEN4009');
     expect(res.status).toBe(200);
     expect(res.text).toContain('ELEN4009');

--- a/tests/integration/studentDashboard.test.js
+++ b/tests/integration/studentDashboard.test.js
@@ -44,7 +44,7 @@ describe('GET /student/dashboard', () => {
 
   test('renders the Find a Consultation calendar section', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/student/dashboard?view=find');
     expect(res.status).toBe(200);
     expect(res.text).toContain('Find a Consultation');
@@ -53,7 +53,7 @@ describe('GET /student/dashboard', () => {
 
   test('calendar shows lecturer names from enrolled courses', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/student/dashboard?view=find');
     expect(res.status).toBe(200);
     expect(res.text).toContain('Clark Kent');
@@ -61,7 +61,7 @@ describe('GET /student/dashboard', () => {
 
   test('calendar renders Schedule buttons for available slots', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/student/dashboard?view=find');
     expect(res.status).toBe(200);
     expect(res.text).toContain('data-testid="schedule-btn"');
@@ -69,7 +69,7 @@ describe('GET /student/dashboard', () => {
 
   test('course colour legend renders enrolled course codes', async () => {
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/student/dashboard?view=find');
     expect(res.status).toBe(200);
     expect(res.text).toContain('ELEN4010');
@@ -86,7 +86,7 @@ describe('GET /student/dashboard', () => {
     const firstWeekday = getFirstCalendarWeekday();
     getSAPublicHolidays.mockResolvedValueOnce([{ date: firstWeekday, localName: 'Test Holiday' }]);
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/student/dashboard?view=find');
     expect(res.status).toBe(200);
     expect(res.text).toContain('Public holiday');
@@ -114,7 +114,7 @@ describe('public holidays and weather integration', () => {
     getSAPublicHolidays.mockResolvedValueOnce([{ date: firstWeekday, localName: 'Test Holiday' }]);
     getWitsWeather.mockResolvedValueOnce({});
     const agent = request.agent(app);
-    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'pass' });
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
     const res = await agent.get('/student/dashboard?view=find');
     expect(res.status).toBe(200);
     expect(res.text).toContain('Public holiday');

--- a/tests/unit/activity-log-helpers.test.js
+++ b/tests/unit/activity-log-helpers.test.js
@@ -1,0 +1,118 @@
+/* eslint-env jest */
+const { getEventLabel, getCategory, getStatus, resolveActorFallback } = require('../../src/services/activity-log-helpers');
+
+describe('getEventLabel', () => {
+  test('maps known action names to readable labels', () => {
+    expect(getEventLabel('USER_LOGIN')).toBe('Logged in');
+    expect(getEventLabel('USER_LOGOUT')).toBe('Logged out');
+    expect(getEventLabel('USER_SIGNUP')).toBe('Signed up');
+    expect(getEventLabel('AUTH_FAILED_LOGIN')).toBe('Failed login attempt');
+    expect(getEventLabel('CONSULT_CREATE')).toBe('Booked consultation');
+    expect(getEventLabel('CONSULT_JOIN')).toBe('Joined consultation');
+    expect(getEventLabel('CONSULT_LEAVE')).toBe('Left consultation');
+    expect(getEventLabel('CONSULT_CANCEL_ORG')).toBe('Cancelled own consultation');
+    expect(getEventLabel('CONSULT_CANCEL_LEC')).toBe('Lecturer cancelled consultation');
+    expect(getEventLabel('AVAIL_CREATE')).toBe('Created availability');
+    expect(getEventLabel('AVAIL_CANCEL')).toBe('Deleted availability');
+    expect(getEventLabel('AVAIL_UPDATE')).toBe('Updated availability');
+    expect(getEventLabel('PROFILE_COURSES_UPDATED')).toBe('Updated courses');
+    expect(getEventLabel('ADMIN_LOGIN')).toBe('Admin logged in');
+    expect(getEventLabel('ADMIN_USER_ADD')).toBe('Added record');
+    expect(getEventLabel('ADMIN_USER_EDIT')).toBe('Edited record');
+    expect(getEventLabel('ADMIN_USER_DELETE')).toBe('Deleted record');
+  });
+
+  test('returns the raw action name for unknown codes', () => {
+    expect(getEventLabel('UNKNOWN_ACTION')).toBe('UNKNOWN_ACTION');
+    expect(getEventLabel('')).toBe('');
+  });
+});
+
+describe('getCategory', () => {
+  test('maps auth actions to Auth', () => {
+    expect(getCategory('USER_LOGIN')).toBe('Auth');
+    expect(getCategory('USER_LOGOUT')).toBe('Auth');
+    expect(getCategory('USER_SIGNUP')).toBe('Auth');
+    expect(getCategory('AUTH_FAILED_LOGIN')).toBe('Auth');
+    expect(getCategory('ADMIN_LOGIN')).toBe('Auth');
+  });
+
+  test('maps consultation booking actions to Booking', () => {
+    expect(getCategory('CONSULT_CREATE')).toBe('Booking');
+    expect(getCategory('CONSULT_JOIN')).toBe('Booking');
+    expect(getCategory('CONSULT_LEAVE')).toBe('Booking');
+  });
+
+  test('maps cancellation actions to Cancellation', () => {
+    expect(getCategory('CONSULT_CANCEL_ORG')).toBe('Cancellation');
+    expect(getCategory('CONSULT_CANCEL_LEC')).toBe('Cancellation');
+  });
+
+  test('maps availability actions to Availability', () => {
+    expect(getCategory('AVAIL_CREATE')).toBe('Availability');
+    expect(getCategory('AVAIL_CANCEL')).toBe('Availability');
+    expect(getCategory('AVAIL_UPDATE')).toBe('Availability');
+  });
+
+  test('maps admin CRUD actions to Admin', () => {
+    expect(getCategory('ADMIN_USER_ADD')).toBe('Admin');
+    expect(getCategory('ADMIN_USER_EDIT')).toBe('Admin');
+    expect(getCategory('ADMIN_USER_DELETE')).toBe('Admin');
+  });
+
+  test('returns System for unknown action names', () => {
+    expect(getCategory('UNKNOWN')).toBe('System');
+    expect(getCategory('')).toBe('System');
+  });
+});
+
+describe('getStatus', () => {
+  test('returns Failed for AUTH_FAILED_LOGIN', () => {
+    expect(getStatus('AUTH_FAILED_LOGIN')).toBe('Failed');
+  });
+
+  test('returns Cancelled for cancellation actions', () => {
+    expect(getStatus('CONSULT_CANCEL_ORG')).toBe('Cancelled');
+    expect(getStatus('CONSULT_CANCEL_LEC')).toBe('Cancelled');
+  });
+
+  test('returns Deleted for delete actions', () => {
+    expect(getStatus('AVAIL_CANCEL')).toBe('Deleted');
+    expect(getStatus('ADMIN_USER_DELETE')).toBe('Deleted');
+  });
+
+  test('returns Updated for update actions', () => {
+    expect(getStatus('AVAIL_UPDATE')).toBe('Updated');
+    expect(getStatus('ADMIN_USER_EDIT')).toBe('Updated');
+  });
+
+  test('returns Success for normal completed actions', () => {
+    expect(getStatus('USER_LOGIN')).toBe('Success');
+    expect(getStatus('CONSULT_CREATE')).toBe('Success');
+    expect(getStatus('AVAIL_CREATE')).toBe('Success');
+    expect(getStatus('ADMIN_USER_ADD')).toBe('Success');
+  });
+});
+
+describe('resolveActorFallback', () => {
+  test('returns Unknown Student when actor_role is Student', () => {
+    expect(resolveActorFallback('1234567', 'Student')).toBe('Unknown Student');
+  });
+
+  test('returns Unknown Lecturer when actor_role is Lecturer', () => {
+    expect(resolveActorFallback('A000356', 'Lecturer')).toBe('Unknown Lecturer');
+  });
+
+  test('returns Unknown Admin when actor_role is Admin', () => {
+    expect(resolveActorFallback('ADMIN001', 'Admin')).toBe('Unknown Admin');
+  });
+
+  test('returns the userId when actor_role is Unknown', () => {
+    expect(resolveActorFallback('A000356', 'Unknown')).toBe('A000356');
+  });
+
+  test('returns System when userId is falsy', () => {
+    expect(resolveActorFallback(null, 'Unknown')).toBe('System');
+    expect(resolveActorFallback('',   'Unknown')).toBe('System');
+  });
+});

--- a/tests/unit/admin-controller.test.js
+++ b/tests/unit/admin-controller.test.js
@@ -29,7 +29,7 @@ const mockRes = () => {
   return res
 }
 
-const TABLES = [{ name: 'admins' }, { name: 'courses' }, { name: 'departments' }, { name: 'admin_audit_log' }]
+const TABLES = [{ name: 'actions' }, { name: 'activity_log' }, { name: 'admins' }, { name: 'affected_records' }, { name: 'courses' }, { name: 'departments' }, { name: 'admin_audit_log' }]
 const COLUMNS = [
   { cid: 0, name: 'admin_id', type: 'TEXT', notnull: 1, dflt_value: null, pk: 1 },
   { cid: 1, name: 'name', type: 'TEXT', notnull: 1, dflt_value: null, pk: 0 }
@@ -98,7 +98,7 @@ describe('showAdminDashboard', () => {
     await showAdminDashboard(req, res)
 
     expect(res.render).toHaveBeenCalledWith('admin-dashboard', expect.objectContaining({
-      tables: ['admins', 'courses', 'departments', 'admin_audit_log'],
+      tables: ['actions', 'activity_log', 'admins', 'affected_records', 'courses', 'departments', 'admin_audit_log'],
       activeTable: null,
       columns: [],
       rows: []
@@ -184,6 +184,24 @@ describe('createRecord', () => {
 
     expect(res.redirect).toHaveBeenCalledWith('/admin/table/admin_audit_log?error=This+table+is+read-only')
     expect(logAdminAudit).not.toHaveBeenCalled()
+  })
+
+  test('blocks inserts into activity_log', async () => {
+    const res = mockRes()
+    await createRecord(mockReq({ params: { tableName: 'activity_log' }, body: {} }), res)
+    expect(res.redirect).toHaveBeenCalledWith('/admin/table/activity_log?error=This+table+is+read-only')
+  })
+
+  test('blocks inserts into affected_records', async () => {
+    const res = mockRes()
+    await createRecord(mockReq({ params: { tableName: 'affected_records' }, body: {} }), res)
+    expect(res.redirect).toHaveBeenCalledWith('/admin/table/affected_records?error=This+table+is+read-only')
+  })
+
+  test('blocks inserts into actions', async () => {
+    const res = mockRes()
+    await createRecord(mockReq({ params: { tableName: 'actions' }, body: {} }), res)
+    expect(res.redirect).toHaveBeenCalledWith('/admin/table/actions?error=This+table+is+read-only')
   })
 
   test('does not call logAdminAudit when the insert fails', async () => {

--- a/tests/unit/auth-controller.test.js
+++ b/tests/unit/auth-controller.test.js
@@ -11,6 +11,7 @@ jest.mock('../../src/services/logging-service', () => ({
 
 const db = require('../../database/db')
 const { logActivity } = require('../../src/services/logging-service')
+const ActionTypes = require('../../src/services/action-types')
 
 const mockReq = (overrides = {}) => ({
   session: {},
@@ -131,6 +132,19 @@ describe('login', () => {
     expect(req.session.userName).toBe('System Admin')
     expect(req.session.userRole).toBe('admin')
     expect(res.redirect).toHaveBeenCalledWith('/admin/dashboard')
+  })
+
+  test('logs ADMIN_LOGIN (not USER_LOGIN) when admin credentials are valid', async () => {
+    const fakeAdmin = { admin_id: 'ADMIN001', name: 'System Admin', password: 'admin' }
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeAdmin) })
+
+    await login(mockReq({ body: { staffStudentNumber: 'ADMIN001', password: 'admin' } }), mockRes())
+
+    expect(logActivity).toHaveBeenCalledWith('ADMIN001', ActionTypes.ADMIN_LOGIN, [])
+    expect(logActivity).not.toHaveBeenCalledWith('ADMIN001', ActionTypes.USER_LOGIN, [])
   })
 
   test('renders error when no staff, student, or admin matches', async () => {

--- a/tests/unit/availability-controller.test.js
+++ b/tests/unit/availability-controller.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-const { showAvailability, saveAvailability, deleteAvailability } = require('../../src/controllers/availability-controller')
+const { showAvailability, saveAvailability, deleteAvailability, updateAvailability } = require('../../src/controllers/availability-controller')
 
 jest.mock('../../database/db', () => ({ prepare: jest.fn() }))
 
@@ -149,6 +149,118 @@ describe('saveAvailability', () => {
     expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
       error: expect.stringContaining('overlaps'),
       success: null
+    }))
+  })
+})
+
+describe('updateAvailability', () => {
+  const validBody = {
+    day_of_week: 'Mon',
+    start_time: '09:00',
+    end_time: '10:00',
+    venue: 'Room 2',
+    max_number_of_students: '3',
+    max_booking_min: '45'
+  }
+  const existingSlot = { availability_id: 1, staff_number: 'A000356', day_of_week: 'Mon', start_time: '09:00', end_time: '10:00' }
+
+  test('updates slot and renders success when valid and no overlap with other slots', async () => {
+    const runFn = jest.fn()
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(existingSlot) })  // slot ownership check
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })             // other slots overlap check
+      .mockReturnValueOnce({ run: runFn })                                     // UPDATE
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue(fakeSlots) })      // getAvailability after update
+
+    const req = mockReq({ params: { id: '1' }, body: validBody })
+    const res = mockRes()
+    await updateAvailability(req, res)
+
+    expect(runFn).toHaveBeenCalledWith('Mon', '09:00', '10:00', 'Room 2', 3, 45, '1', 'A000356')
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      success: 'Availability slot updated.',
+      error: null
+    }))
+  })
+
+  test('logs AVAIL_UPDATE with the correct slot id on success', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(existingSlot) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+      .mockReturnValueOnce({ run: jest.fn() })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+
+    await updateAvailability(mockReq({ params: { id: '1' }, body: validBody }), mockRes())
+
+    expect(logActivity).toHaveBeenCalledWith('A000356', 302, [{ table: 'lecturer_availability', id: '1' }])
+  })
+
+  test('renders error when slot does not belong to the lecturer', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })           // slot not found
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })             // getAvailability for render
+
+    const req = mockReq({ params: { id: '99' }, body: validBody })
+    const res = mockRes()
+    await updateAvailability(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: 'Slot not found.'
+    }))
+    expect(logActivity).not.toHaveBeenCalled()
+  })
+
+  test('renders error when updated slot overlaps another slot', async () => {
+    const conflicting = { start_time: '09:30', end_time: '10:30' }
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(existingSlot) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([conflicting]) })  // other slots have overlap
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([existingSlot]) }) // getAvailability for render
+
+    const req = mockReq({ params: { id: '1' }, body: { ...validBody, start_time: '09:00', end_time: '10:00' } })
+    const res = mockRes()
+    await updateAvailability(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: expect.stringContaining('overlaps')
+    }))
+    expect(logActivity).not.toHaveBeenCalled()
+  })
+
+  test('renders error when required fields are missing', async () => {
+    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) })
+
+    const req = mockReq({ params: { id: '1' }, body: { day_of_week: '', start_time: '', end_time: '', venue: '', max_number_of_students: '' } })
+    const res = mockRes()
+    await updateAvailability(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: 'All fields are required.'
+    }))
+    expect(logActivity).not.toHaveBeenCalled()
+  })
+
+  test('renders error when times are outside business hours', async () => {
+    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) })
+
+    const req = mockReq({ params: { id: '1' }, body: { ...validBody, start_time: '06:00', end_time: '07:00' } })
+    const res = mockRes()
+    await updateAvailability(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: expect.stringContaining('08:00 and 18:00')
+    }))
+  })
+
+  test('renders error when max students exceeds 10', async () => {
+    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) })
+
+    const req = mockReq({ params: { id: '1' }, body: { ...validBody, max_number_of_students: '15' } })
+    const res = mockRes()
+    await updateAvailability(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: 'Max students must be between 1 and 10.'
     }))
   })
 })

--- a/tests/unit/lecturer-consultations-controller.test.js
+++ b/tests/unit/lecturer-consultations-controller.test.js
@@ -2,8 +2,11 @@
 const { showLecturerConsultations, cancelLecturerConsultation } = require('../../src/controllers/lecturer-consultations-controller');
 
 jest.mock('../../database/db', () => ({ prepare: jest.fn() }));
+jest.mock('../../src/services/logging-service', () => ({ logActivity: jest.fn().mockResolvedValue(true) }));
 
 const db = require('../../database/db');
+const { logActivity } = require('../../src/services/logging-service');
+const ActionTypes = require('../../src/services/action-types');
 
 const TODAY  = new Date().toISOString().split('T')[0];
 const FUTURE = '2099-12-31';
@@ -90,52 +93,68 @@ describe('showLecturerConsultations()', () => {
 });
 
 describe('cancelLecturerConsultation()', () => {
-  beforeEach(() => db.prepare.mockReset());
+  beforeEach(() => { db.prepare.mockReset(); logActivity.mockClear(); });
 
-  test('redirects with error when consultation is not found', () => {
+  test('redirects with error when consultation is not found', async () => {
     db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) });
     const res = mockRes();
-    cancelLecturerConsultation(mockReq({ params: { constId: '99' } }), res);
+    await cancelLecturerConsultation(mockReq({ params: { constId: '99' } }), res);
     expect(res.redirect).toHaveBeenCalledWith('/lecturer/consultations?error=Consultation+not+found');
+    expect(logActivity).not.toHaveBeenCalled();
   });
 
-  test('redirects with error when consultation is already cancelled', () => {
+  test('redirects with error when consultation is already cancelled', async () => {
     db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue({ const_id: 1, status: 'Cancelled', consultation_date: FUTURE }) });
     const res = mockRes();
-    cancelLecturerConsultation(mockReq({ params: { constId: '1' } }), res);
+    await cancelLecturerConsultation(mockReq({ params: { constId: '1' } }), res);
     expect(res.redirect).toHaveBeenCalledWith('/lecturer/consultations?error=Consultation+is+already+cancelled');
+    expect(logActivity).not.toHaveBeenCalled();
   });
 
-  test('redirects with error when consultation is in the past', () => {
+  test('redirects with error when consultation is in the past', async () => {
     db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue({ const_id: 1, status: 'Booked', consultation_date: PAST }) });
     const res = mockRes();
-    cancelLecturerConsultation(mockReq({ params: { constId: '1' } }), res);
+    await cancelLecturerConsultation(mockReq({ params: { constId: '1' } }), res);
     expect(res.redirect).toHaveBeenCalledWith('/lecturer/consultations?error=Cannot+cancel+a+past+consultation');
+    expect(logActivity).not.toHaveBeenCalled();
   });
 
-  test('updates status to Cancelled and redirects with success', () => {
+  test('updates status to Cancelled and redirects with success', async () => {
     db.prepare
       .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ const_id: 1, status: 'Available', consultation_date: FUTURE }) })
       .mockReturnValueOnce({ run: jest.fn() });
     const res = mockRes();
-    cancelLecturerConsultation(mockReq({ params: { constId: '1' } }), res);
+    await cancelLecturerConsultation(mockReq({ params: { constId: '1' } }), res);
     expect(res.redirect).toHaveBeenCalledWith('/lecturer/consultations?success=Consultation+cancelled+successfully');
   });
 
-  test('calls UPDATE with the correct constId', () => {
+  test('logs CONSULT_CANCEL_LEC with the correct lecturer and consultation ID on success', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ const_id: '1', status: 'Available', consultation_date: FUTURE }) })
+      .mockReturnValueOnce({ run: jest.fn() });
+    await cancelLecturerConsultation(mockReq({ params: { constId: '1' } }), mockRes());
+    expect(logActivity).toHaveBeenCalledWith(
+      'A000356',
+      ActionTypes.CONSULT_CANCEL_LEC,
+      [{ table: 'consultations', id: '1' }]
+    );
+  });
+
+  test('calls UPDATE with the correct constId', async () => {
     const runMock = jest.fn();
     db.prepare
       .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ const_id: 42, status: 'Booked', consultation_date: FUTURE }) })
       .mockReturnValueOnce({ run: runMock });
-    cancelLecturerConsultation(mockReq({ params: { constId: '42' } }), mockRes());
+    await cancelLecturerConsultation(mockReq({ params: { constId: '42' } }), mockRes());
     expect(runMock).toHaveBeenCalledWith('42');
   });
 
-  test('redirects with error when DB throws', () => {
+  test('redirects with error when DB throws', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
     db.prepare.mockReturnValueOnce({ get: jest.fn().mockImplementation(() => { throw new Error('DB error'); }) });
     const res = mockRes();
-    cancelLecturerConsultation(mockReq({ params: { constId: '1' } }), res);
+    await cancelLecturerConsultation(mockReq({ params: { constId: '1' } }), res);
     expect(res.redirect).toHaveBeenCalledWith('/lecturer/consultations?error=Could+not+cancel+consultation.+Please+try+again.');
+    expect(logActivity).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Related #5 

## What Was Changed

### Unified Admin Activity Log Page

- The admin dashboard Security section now links to a single readable Activity Log page at `/admin/activity-log`.
- This page surfaces the existing `activity_log`, `affected_records`, and `actions` tables that were already built.
- It joins them with `students`, `staff`, and `admins` to show actor names instead of raw IDs.
- Each row shows:
  - timestamp
  - actor name
  - role
  - event label
  - category chip
  - status chip
- A **View** button opens a detail modal with the full entry, including affected records.
- Category filter buttons and search are included.
- Pagination uses `LIMIT` and `OFFSET`.
- The page is read-only.

### Activity Log Helper Service

- Added `activity-log-helpers.js`.
- It maps the existing action codes from `action-types.js` to readable:
  - labels
  - categories
  - statuses

### Fixed Logging Gaps

- Admin login was using `USER_LOGIN` instead of `ADMIN_LOGIN`.
- `cancelLecturerConsultation` was not calling `logActivity`.
- It now logs `CONSULT_CANCEL_LEC` on success.

### Lecturer Edit Availability

- Lecturers can now edit existing availability slots from the Availability page using a Bootstrap modal.
- Validation covers:
  - required fields
  - business hours
  - max students
  - day overlap
- Successful edits now log `AVAIL_UPDATE` using the existing action type.

### Admin Dashboard Improvements

- `activity_log`, `affected_records`, and `actions` are now marked read-only in the admin table browser.
- The consultations View modal now shows:
  - course name
  - lecturer name
  - organiser name
  
instead of raw IDs.

- The Delete button label was corrected from `"Del"` to `"Delete"`.

### Tests

- Unit and integration tests were added for all new behaviour.
- Existing tests were updated where affected.