### PR TITLE
Feat/input validation

### DIFF
--- a/database/createSchema.sql
+++ b/database/createSchema.sql
@@ -212,3 +212,6 @@ CREATE INDEX idx_polymorphic_lookup
 
 CREATE INDEX idx_user_history
     ON activity_log(user_id);
+
+CREATE INDEX idx_activity_log_action_created
+    ON activity_log(action_id, created_at);

--- a/documentation/ADR's/ADR-012-Security.md
+++ b/documentation/ADR's/ADR-012-Security.md
@@ -185,3 +185,36 @@ All user-supplied output is rendered through EJS escaped output (`<%= %>`). Unes
 - Oversized input is rejected with a clear message before reaching the database.
 - SQL injection via prepared statements was already in place; this decision documents and confirms that coverage.
 - Client-side `maxlength` attributes remain for UX but are no longer the sole enforcement point.
+
+---
+
+<!-- Append new decisions below this line using the same structure -->
+
+## Decision 7 — Activity Log Query Index (2026-05-16)
+
+**Related to:** Decision 6 (activity log infrastructure), PR review feedback
+
+### Context
+
+The `showActivityLog` and `showFailedLogins` views sort the `activity_log` table by `created_at DESC` and filter by `action_id` (via a JOIN to `actions`). As the log grows with every user action across the system, this sort becomes a full table scan — there was no index covering both the join column and the sort column.
+
+A PR review comment flagged this after Decision 6 introduced the Failed Logins view, which filters by `action_name = 'AUTH_FAILED_LOGIN'` through the same JOIN path.
+
+### Decision
+
+A composite index was added to `createSchema.sql`:
+
+```sql
+CREATE INDEX idx_activity_log_action_created
+    ON activity_log(action_id, created_at);
+```
+
+This covers the JOIN filter on `action_id` and the `ORDER BY created_at DESC` sort in a single index scan, avoiding a full table scan for both the general activity log and the failed-logins filtered view.
+
+The existing `idx_user_history` index on `activity_log(user_id)` was retained — it serves a different access pattern (per-user history lookups) and is not redundant with this new index.
+
+### Consequences
+
+- The `ORDER BY created_at DESC` sort on both the Activity Log and Failed Logins pages is backed by an index and will remain efficient as log volume grows.
+- No application code changes were required — the index is transparent to the query layer.
+- Accepted trade-off: the index adds a small write overhead on every `INSERT` into `activity_log`. Given that log writes are infrequent relative to reads (every user action writes one row), this overhead is negligible.

--- a/documentation/ADR's/ADR-012-Security.md
+++ b/documentation/ADR's/ADR-012-Security.md
@@ -157,3 +157,31 @@ The response to step 1 is always "if an account exists, a link has been sent" �
 - A database breach does not expose reset tokens (only SHA-256 hashes are stored).
 - The 1-hour expiry and one-time-use token limit the window of a stolen link.
 - Email addresses are not enumerable through this endpoint.
+
+---
+
+## Decision 6 — Server-Side Input Validation and Output Encoding (2026-05-17)
+
+**Related to:** Epic #6 (Authenticate Securely), user story: input validation and XSS protection
+
+### Context
+
+The application accepts user-supplied input through signup, consultation booking, and lecturer availability forms. Client-side validation (HTML `maxlength`, `required`) improves user experience but cannot be trusted — users can bypass the browser and send requests directly to the server.
+
+### Decision
+
+User-controlled fields are validated on the server before any database write, using a shared `src/services/input-validation.js` helper:
+
+- Consultation title: required, max 100 characters.
+- Consultation description: optional, max 500 characters.
+- Availability venue: required, max 100 characters.
+- Signup full name: required, max 100 characters.
+
+All user-supplied output is rendered through EJS escaped output (`<%= %>`). Unescaped output (`<%- %>`) is only used for server-constructed JSON payloads (schema metadata, course lists) that do not contain raw user input. Database access uses `better-sqlite3` prepared statements with bound parameters throughout — no string interpolation in SQL values.
+
+### Consequences
+
+- Stored XSS risk is reduced: script tags submitted in form fields are stored as plain text and rendered escaped, so they never execute in the browser.
+- Oversized input is rejected with a clear message before reaching the database.
+- SQL injection via prepared statements was already in place; this decision documents and confirms that coverage.
+- Client-side `maxlength` attributes remain for UX but are no longer the sole enforcement point.

--- a/src/controllers/admin-activity-log-controller.js
+++ b/src/controllers/admin-activity-log-controller.js
@@ -59,7 +59,6 @@ const showActivityLog = (req, res) => {
   const search         = (req.query.search  || '').trim();
   const categoryFilter = (req.query.category || '').trim();
 
-  const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all().map(r => r.name);
   const { where, params } = buildWhere(search, categoryFilter);
 
   try {
@@ -111,7 +110,6 @@ const showActivityLog = (req, res) => {
 
     res.render('admin-activity-log', {
       user,
-      tables,
       rows: enriched,
       page,
       pageSize: PAGE_SIZE,
@@ -132,7 +130,6 @@ const showActivityLog = (req, res) => {
     console.error('showActivityLog error:', err);
     res.render('admin-activity-log', {
       user,
-      tables,
       rows: [],
       page: 1,
       pageSize: PAGE_SIZE,
@@ -157,8 +154,6 @@ const showFailedLogins = (req, res) => {
   const page   = Math.max(1, parseInt(req.query.page) || 1);
   const offset = (page - 1) * PAGE_SIZE;
   const search = (req.query.search || '').trim();
-
-  const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all().map(r => r.name);
 
   const parts  = ["a.action_name = 'AUTH_FAILED_LOGIN'"];
   const params = [];
@@ -204,7 +199,6 @@ const showFailedLogins = (req, res) => {
 
     res.render('admin-activity-log', {
       user,
-      tables,
       rows: enriched,
       page,
       pageSize: PAGE_SIZE,
@@ -225,7 +219,6 @@ const showFailedLogins = (req, res) => {
     console.error('showFailedLogins error:', err);
     res.render('admin-activity-log', {
       user,
-      tables,
       rows: [],
       page: 1,
       pageSize: PAGE_SIZE,

--- a/src/controllers/admin-activity-log-controller.js
+++ b/src/controllers/admin-activity-log-controller.js
@@ -4,6 +4,13 @@ const { getEventLabel, getCategory, getStatus, resolveActorFallback, CATEGORY_AC
 const PAGE_SIZE = 20;
 const ADMIN_CRUD_ACTIONS = new Set(['ADMIN_USER_ADD', 'ADMIN_USER_EDIT', 'ADMIN_USER_DELETE']);
 
+const getFailedLoginCount = () =>
+  db.prepare(`
+    SELECT COUNT(*) as n FROM activity_log al
+    JOIN actions a ON al.action_id = a.action_id
+    WHERE a.action_name = 'AUTH_FAILED_LOGIN'
+  `).get().n;
+
 const fetchAuditData = (userId, createdAt) =>
   db.prepare(`
     SELECT old_data, new_data FROM admin_audit_log
@@ -113,6 +120,11 @@ const showActivityLog = (req, res) => {
       search,
       categoryFilter,
       categories: Object.keys(CATEGORY_ACTIONS),
+      failedLoginCount: getFailedLoginCount(),
+      pageTitle: 'Activity Log',
+      pageSubtitle: 'System-wide record of all user actions across students, lecturers, and administrators.',
+      formAction: '/admin/activity-log',
+      showCategoryFilter: true,
       error:   req.query.error   || null,
       success: req.query.success || null,
     });
@@ -129,10 +141,108 @@ const showActivityLog = (req, res) => {
       search,
       categoryFilter,
       categories: Object.keys(CATEGORY_ACTIONS),
+      failedLoginCount: getFailedLoginCount(),
+      pageTitle: 'Activity Log',
+      pageSubtitle: 'System-wide record of all user actions across students, lecturers, and administrators.',
+      formAction: '/admin/activity-log',
+      showCategoryFilter: true,
       error:   'Could not load activity log. Please try again.',
       success: null,
     });
   }
 };
 
-module.exports = { showActivityLog };
+const showFailedLogins = (req, res) => {
+  const user   = { id: req.session.userId, name: req.session.userName };
+  const page   = Math.max(1, parseInt(req.query.page) || 1);
+  const offset = (page - 1) * PAGE_SIZE;
+  const search = (req.query.search || '').trim();
+
+  const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").all().map(r => r.name);
+
+  const parts  = ["a.action_name = 'AUTH_FAILED_LOGIN'"];
+  const params = [];
+  if (search) {
+    parts.push(`(COALESCE(st.name, stf.name, adm.name) LIKE ? OR al.user_id LIKE ?)`);
+    const like = `%${search}%`;
+    params.push(like, like);
+  }
+  const where = `WHERE ${parts.join(' AND ')}`;
+
+  try {
+    const totalRows = db.prepare(`
+      SELECT COUNT(DISTINCT al.log_id) as count ${BASE_FROM} ${where}
+    `).get(...params).count;
+
+    const rows = db.prepare(`
+      SELECT
+        al.log_id, al.user_id, al.created_at,
+        a.action_name, a.page_context, a.description,
+        COALESCE(st.name, stf.name, adm.name) AS actor_name,
+        CASE
+          WHEN st.student_number IS NOT NULL THEN 'Student'
+          WHEN stf.staff_number  IS NOT NULL THEN 'Lecturer'
+          WHEN adm.admin_id      IS NOT NULL THEN 'Admin'
+          ELSE 'Unknown'
+        END AS actor_role,
+        GROUP_CONCAT(ar.table_affected || ':' || ar.record_id, ' | ') AS affected_summary
+      ${BASE_FROM} ${where}
+      GROUP BY al.log_id
+      ORDER BY al.created_at DESC
+      LIMIT ? OFFSET ?
+    `).all(...params, PAGE_SIZE, offset);
+
+    const enriched = rows.map(row => ({
+      ...row,
+      eventLabel: getEventLabel(row.action_name),
+      category:   getCategory(row.action_name),
+      status:     getStatus(row.action_name),
+      actorName:  row.actor_name || resolveActorFallback(row.user_id, row.actor_role),
+      old_data:   null,
+      new_data:   null,
+    }));
+
+    res.render('admin-activity-log', {
+      user,
+      tables,
+      rows: enriched,
+      page,
+      pageSize: PAGE_SIZE,
+      totalPages: Math.max(1, Math.ceil(totalRows / PAGE_SIZE)),
+      totalRows,
+      search,
+      categoryFilter: '',
+      categories: [],
+      failedLoginCount: totalRows,
+      pageTitle: 'Failed Logins',
+      pageSubtitle: 'All failed login attempts recorded in the system.',
+      formAction: '/admin/failed-logins',
+      showCategoryFilter: false,
+      error:   req.query.error || null,
+      success: null,
+    });
+  } catch (err) {
+    console.error('showFailedLogins error:', err);
+    res.render('admin-activity-log', {
+      user,
+      tables,
+      rows: [],
+      page: 1,
+      pageSize: PAGE_SIZE,
+      totalPages: 1,
+      totalRows: 0,
+      search,
+      categoryFilter: '',
+      categories: [],
+      failedLoginCount: getFailedLoginCount(),
+      pageTitle: 'Failed Logins',
+      pageSubtitle: 'All failed login attempts recorded in the system.',
+      formAction: '/admin/failed-logins',
+      showCategoryFilter: false,
+      error:   'Could not load failed logins. Please try again.',
+      success: null,
+    });
+  }
+};
+
+module.exports = { showActivityLog, showFailedLogins, getFailedLoginCount };

--- a/src/controllers/admin-controller.js
+++ b/src/controllers/admin-controller.js
@@ -3,6 +3,7 @@ const { logActivity } = require('../services/logging-service')
 const ActionTypes = require('../services/action-types')
 const { FK_DISPLAY, getInputType, friendlyError, buildSearchQuery } = require('../services/admin-helpers')
 const { logAdminAudit } = require('../services/admin-audit-service')
+const { getFailedLoginCount } = require('./admin-activity-log-controller')
 
 const PAGE_SIZE = 20
 // tables the admin UI can view but not modify
@@ -64,6 +65,7 @@ const showAdminDashboard = (req, res) => {
     search: '',
     fkOptions: {},
     inputTypes: {},
+    failedLoginCount: getFailedLoginCount(),
     error: null,
     success: null
   })
@@ -134,6 +136,7 @@ const showTable = (req, res) => {
     search,
     fkOptions,
     inputTypes,
+    failedLoginCount: getFailedLoginCount(),
     error: req.query.error || null,
     success: req.query.success || null
   })

--- a/src/controllers/availability-controller.js
+++ b/src/controllers/availability-controller.js
@@ -3,6 +3,7 @@ const { logActivity } = require('../services/logging-service')
 const ActionTypes = require('../services/action-types')
 
 const { validateSlotFields, isBusinessHours, isOverlapping } = require('../services/availability-helpers')
+const { validateRequiredText } = require('../services/input-validation')
 
 const getAvailability = (staffNumber) =>
   db.prepare(`
@@ -27,6 +28,16 @@ const saveAvailability = async (req, res) => {
       user,
       availability: getAvailability(user.id),
       error: 'All fields are required.',
+      success: null
+    })
+  }
+
+  const venueError = validateRequiredText('Venue', venue, 100)
+  if (venueError) {
+    return res.render('availability', {
+      user,
+      availability: getAvailability(user.id),
+      error: venueError,
       success: null
     })
   }
@@ -99,6 +110,14 @@ const updateAvailability = async (req, res) => {
     return res.render('availability', {
       user, availability: getAvailability(user.id),
       error: 'All fields are required.', success: null
+    })
+  }
+
+  const venueError = validateRequiredText('Venue', venue, 100)
+  if (venueError) {
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: venueError, success: null
     })
   }
 

--- a/src/controllers/consultation-booking-controller.js
+++ b/src/controllers/consultation-booking-controller.js
@@ -5,6 +5,7 @@ const ActionTypes = require('../services/action-types')
 const { computeBookableChunks, validateBookingRequest, getNextNWeekdays } = require('../services/booking-helpers')
 const { generateConstId } = require('../services/availability-helpers')
 const { getWitsWeather } = require('../services/weather-service')
+const { validateRequiredText, validateOptionalText, cleanText } = require('../services/input-validation')
 
 const getStudentUser = (req) => req.session && req.session.userId
   ? { id: req.session.userId, name: req.session.userName, role: req.session.userRole }
@@ -121,6 +122,23 @@ const createBooking = async (req, res) => {
     )
   }
 
+  const titleError = validateRequiredText('Title', title, 100)
+  if (titleError) {
+    return res.redirect(
+      `/consultations/new?staffNumber=${staff_number}&availabilityId=${availability_id}&date=${date}&error=${encodeURIComponent(titleError)}`
+    )
+  }
+
+  const descError = validateOptionalText('Description', description, 500)
+  if (descError) {
+    return res.redirect(
+      `/consultations/new?staffNumber=${staff_number}&availabilityId=${availability_id}&date=${date}&error=${encodeURIComponent(descError)}`
+    )
+  }
+
+  const cleanTitle = cleanText(title)
+  const cleanDescription = description ? cleanText(description) : null
+
   const window = db.prepare(
     'SELECT * FROM lecturer_availability WHERE availability_id = ? AND staff_number = ?'
   ).get(availability_id, staff_number)
@@ -168,7 +186,7 @@ const createBooking = async (req, res) => {
        lecturer_id, organiser, availability_id, duration_min, max_number_of_students, venue, status, allow_join)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'Booked', ?)
   `).run(
-    constId, title, description || null, date, start_time,
+    constId, cleanTitle, cleanDescription, date, start_time,
     staff_number, user.id, availability_id,
     Number(duration_min), window.max_number_of_students, window.venue,
     allowJoinVal

--- a/src/controllers/signup-controller.js
+++ b/src/controllers/signup-controller.js
@@ -4,6 +4,7 @@ const { logActivity } = require('../services/logging-service')
 const ActionTypes = require('../services/action-types')
 const bcrypt = require('bcryptjs')
 const { sendVerificationEmail } = require('../services/email-service')
+const { validateName } = require('../services/input-validation')
 
 const showSignupPage = (req, res) => {
   res.render('sign-up', {
@@ -46,6 +47,11 @@ const registerUser = async (req, res) => {
       password,
       confirmPassword
     } = req.body
+
+    const nameError = validateName('Full name', fullName)
+    if (nameError) {
+      throw new Error(nameError)
+    }
 
     if (password === '') {
       throw new Error('Knock, knock! Who\'s there? Not your password, it seems. Please enter a password to continue')

--- a/src/routes/admin-routes.js
+++ b/src/routes/admin-routes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { showAdminDashboard, showTable, createRecord, updateRecord, deleteRecord } = require('../controllers/admin-controller');
-const { showActivityLog } = require('../controllers/admin-activity-log-controller');
+const { showActivityLog, showFailedLogins } = require('../controllers/admin-activity-log-controller');
 const { requireAuth, requireRole } = require('../middleware/auth-middleware');
 
 const router = express.Router();
@@ -8,6 +8,7 @@ const guard = [requireAuth, requireRole('admin')];
 
 router.get('/admin/dashboard', ...guard, showAdminDashboard);
 router.get('/admin/activity-log', ...guard, showActivityLog);
+router.get('/admin/failed-logins', ...guard, showFailedLogins);
 router.get('/admin/table/:tableName', ...guard, showTable);
 router.post('/admin/table/:tableName/create', ...guard, createRecord);
 router.post('/admin/table/:tableName/:rowId/update', ...guard, updateRecord);

--- a/src/services/input-validation.js
+++ b/src/services/input-validation.js
@@ -1,0 +1,48 @@
+function cleanText(value) {
+  return String(value || '').trim()
+}
+
+function validateRequiredText(fieldName, value, maxLength) {
+  const cleaned = cleanText(value)
+
+  if (!cleaned) {
+    return `${fieldName} is required.`
+  }
+
+  if (cleaned.length > maxLength) {
+    return `${fieldName} must be ${maxLength} characters or fewer.`
+  }
+
+  return null
+}
+
+function validateOptionalText(fieldName, value, maxLength) {
+  const cleaned = cleanText(value)
+
+  if (cleaned.length > maxLength) {
+    return `${fieldName} must be ${maxLength} characters or fewer.`
+  }
+
+  return null
+}
+
+function validateName(fieldName, value) {
+  const cleaned = cleanText(value)
+
+  if (!cleaned) {
+    return `${fieldName} is required.`
+  }
+
+  if (cleaned.length > 100) {
+    return `${fieldName} must be 100 characters or fewer.`
+  }
+
+  return null
+}
+
+module.exports = {
+  cleanText,
+  validateRequiredText,
+  validateOptionalText,
+  validateName
+}

--- a/src/views/admin-activity-log.html
+++ b/src/views/admin-activity-log.html
@@ -136,15 +136,18 @@
       <a href="/admin/table/lecturer_availability" class="table-link"><i class="bi bi-clock-history me-1"></i>Lecturer Availability</a>
 
       <span class="adm-nav-label">Security</span>
-      <a href="/admin/activity-log" class="table-link active"><i class="bi bi-journal-check me-1"></i>Activity Log</a>
+      <a href="/admin/activity-log" class="table-link <%= pageTitle === 'Activity Log' ? 'active' : '' %>"><i class="bi bi-journal-check me-1"></i>Activity Log</a>
+      <% if (failedLoginCount > 0) { %>
+        <a href="/admin/failed-logins" class="table-link <%= pageTitle === 'Failed Logins' ? 'active' : '' %>"><i class="bi bi-exclamation-triangle me-1"></i>Failed Logins</a>
+      <% } %>
     </div>
 
     <!-- Main -->
     <div class="flex-grow-1 p-4 adm-main" style="min-width:0;">
 
       <div class="mb-3">
-        <h3 class="adm-heading-green fw-bold mb-1">Activity Log</h3>
-        <p class="text-muted small mb-0">System-wide record of all user actions across students, lecturers, and administrators.</p>
+        <h3 class="adm-heading-green fw-bold mb-1"><%= pageTitle %></h3>
+        <p class="text-muted small mb-0"><%= pageSubtitle %></p>
       </div>
 
       <% if (error) { %>
@@ -156,16 +159,19 @@
 
       <!-- Search + Filter bar -->
       <div class="card p-3 mb-3">
-        <form method="GET" action="/admin/activity-log" class="d-flex flex-wrap gap-2 align-items-center">
+        <form method="GET" action="<%= formAction %>" class="d-flex flex-wrap gap-2 align-items-center">
           <input type="text" name="search" class="form-control form-control-sm" style="max-width:260px;"
             placeholder="Search user, action, page..." value="<%= search %>">
-          <input type="hidden" name="category" value="<%= categoryFilter %>">
+          <% if (showCategoryFilter) { %>
+            <input type="hidden" name="category" value="<%= categoryFilter %>">
+          <% } %>
           <button type="submit" class="btn btn-sm btn-primary">Search</button>
           <% if (search || categoryFilter) { %>
-            <a href="/admin/activity-log" class="btn btn-sm btn-outline-secondary">Clear</a>
+            <a href="<%= formAction %>" class="btn btn-sm btn-outline-secondary">Clear</a>
           <% } %>
         </form>
 
+        <% if (showCategoryFilter) { %>
         <div class="d-flex flex-wrap gap-2 mt-2">
           <a href="/admin/activity-log<%= search ? '?search=' + encodeURIComponent(search) : '' %>"
              class="filter-btn <%= !categoryFilter ? 'active' : '' %>">All</a>
@@ -174,6 +180,7 @@
                class="filter-btn <%= categoryFilter === cat ? 'active' : '' %>"><%= cat %></a>
           <% }); %>
         </div>
+        <% } %>
       </div>
 
       <!-- Results summary -->

--- a/src/views/admin-dashboard.html
+++ b/src/views/admin-dashboard.html
@@ -184,7 +184,9 @@ function formatCol(name) {
 
       <span class="adm-nav-label">Security</span>
       <a href="/admin/activity-log" class="table-link"><i class="bi bi-journal-check me-1"></i>Activity Log</a>
-      <a href="/admin/table/failed_login_log" class="table-link <%= activeTable === 'failed_login_log' ? 'active' : '' %>"><i class="bi bi-exclamation-triangle me-1"></i>Failed Logins</a>
+      <% if (failedLoginCount > 0) { %>
+        <a href="/admin/failed-logins" class="table-link"><i class="bi bi-exclamation-triangle me-1"></i>Failed Logins</a>
+      <% } %>
     </div>
 
     <!-- Main -->

--- a/tests/integration/consultationBooking.test.js
+++ b/tests/integration/consultationBooking.test.js
@@ -108,6 +108,29 @@ describe('POST /consultations/new', () => {
     createdIds.push(row.const_id);
   });
 
+  test('rejects title exceeding 100 characters with an error message', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
+    const longTitle = 'a'.repeat(101);
+    const res = await bookSlot(agent, { title: longTitle });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error');
+    expect(decodeURIComponent(res.headers.location)).toContain('100 characters or fewer');
+  });
+
+  test('stores script tag in title as plain text without executing', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
+    const scriptTitle = `<script>alert(1)</script> ${testTag}`;
+    const res = await bookSlot(agent, { title: scriptTitle, start_time: '10:30' });
+    expect(res.status).toBe(302);
+    const row = db.prepare('SELECT * FROM consultations WHERE consultation_title = ?').get(scriptTitle.trim());
+    if (row) {
+      createdIds.push(row.const_id);
+      expect(row.consultation_title).toBe(scriptTitle.trim());
+    }
+  });
+
   test('rejects booking outside the availability window', async () => {
     const agent = request.agent(app);
     await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });

--- a/tests/unit/admin-activity-log-controller.test.js
+++ b/tests/unit/admin-activity-log-controller.test.js
@@ -1,0 +1,232 @@
+/* eslint-env jest */
+jest.mock('../../database/db', () => ({ prepare: jest.fn() }))
+jest.mock('../../src/services/activity-log-helpers', () => ({
+  getEventLabel: jest.fn(name => name + '_label'),
+  getCategory:   jest.fn(() => 'Auth'),
+  getStatus:     jest.fn(() => 'Success'),
+  resolveActorFallback: jest.fn(() => 'Unknown'),
+  CATEGORY_ACTIONS: {
+    Auth:  ['USER_LOGIN', 'AUTH_FAILED_LOGIN'],
+    Admin: ['ADMIN_USER_ADD', 'ADMIN_USER_EDIT', 'ADMIN_USER_DELETE'],
+  },
+}))
+
+const db = require('../../database/db')
+const { showActivityLog, showFailedLogins, getFailedLoginCount } = require('../../src/controllers/admin-activity-log-controller')
+
+const mockReq = (overrides = {}) => ({
+  session: { userId: 'ADMIN001', userName: 'System Admin' },
+  query: {},
+  ...overrides,
+})
+const mockRes = () => { const r = {}; r.render = jest.fn(); r.redirect = jest.fn(); return r }
+
+const fakeRow = {
+  log_id: 1, user_id: '2345678', created_at: '2026-05-15 10:00:00',
+  action_name: 'USER_LOGIN', page_context: '/login', description: 'User logged in',
+  actor_name: 'Test Student', actor_role: 'Student', affected_summary: null,
+}
+
+const fakeAdminRow = {
+  ...fakeRow, log_id: 2, action_name: 'ADMIN_USER_ADD', actor_role: 'Admin',
+}
+
+const fakeFailedRow = {
+  ...fakeRow, log_id: 3, action_name: 'AUTH_FAILED_LOGIN',
+}
+
+const mockCount  = (n)    => ({ get: jest.fn().mockReturnValue({ count: n }) })
+const mockGetN   = (n)    => ({ get: jest.fn().mockReturnValue({ n }) })
+const mockRows   = (rows) => ({ all: jest.fn().mockReturnValue(rows) })
+const mockAudit  = (data) => ({ get: jest.fn().mockReturnValue(data) })
+
+beforeEach(() => db.prepare.mockReset())
+
+// ── getFailedLoginCount ──────────────────────────────────────────────────────
+
+describe('getFailedLoginCount', () => {
+  test('returns count from DB', () => {
+    db.prepare.mockReturnValueOnce(mockGetN(7))
+    expect(getFailedLoginCount()).toBe(7)
+  })
+
+  test('returns 0 when there are no failed logins', () => {
+    db.prepare.mockReturnValueOnce(mockGetN(0))
+    expect(getFailedLoginCount()).toBe(0)
+  })
+})
+
+// ── showActivityLog ──────────────────────────────────────────────────────────
+
+describe('showActivityLog', () => {
+  test('renders activity log with rows on happy path', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(1))       // COUNT
+      .mockReturnValueOnce(mockRows([fakeRow])) // rows
+      .mockReturnValueOnce(mockGetN(3))         // getFailedLoginCount
+
+    const res = mockRes()
+    showActivityLog(mockReq(), res)
+
+    expect(res.render).toHaveBeenCalledWith('admin-activity-log', expect.objectContaining({
+      pageTitle: 'Activity Log',
+      totalRows: 1,
+      showCategoryFilter: true,
+      formAction: '/admin/activity-log',
+    }))
+    const [, { rows }] = res.render.mock.calls[0]
+    expect(rows[0]).toMatchObject({ action_name: 'USER_LOGIN', old_data: null, new_data: null })
+  })
+
+  test('renders empty state when no rows exist', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(0))
+      .mockReturnValueOnce(mockRows([]))
+      .mockReturnValueOnce(mockGetN(0))
+
+    const res = mockRes()
+    showActivityLog(mockReq(), res)
+
+    const [, { rows, totalRows }] = res.render.mock.calls[0]
+    expect(rows).toHaveLength(0)
+    expect(totalRows).toBe(0)
+  })
+
+  test('fetches audit data for ADMIN_CRUD actions', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(1))
+      .mockReturnValueOnce(mockRows([fakeAdminRow]))
+      .mockReturnValueOnce(mockAudit({ old_data: '{"name":"old"}', new_data: '{"name":"new"}' }))
+      .mockReturnValueOnce(mockGetN(0))
+
+    const res = mockRes()
+    showActivityLog(mockReq(), res)
+
+    const [, { rows }] = res.render.mock.calls[0]
+    expect(rows[0].old_data).toBe('{"name":"old"}')
+    expect(rows[0].new_data).toBe('{"name":"new"}')
+  })
+
+  test('leaves old_data null when no audit record found for ADMIN_CRUD action', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(1))
+      .mockReturnValueOnce(mockRows([fakeAdminRow]))
+      .mockReturnValueOnce(mockAudit(null))
+      .mockReturnValueOnce(mockGetN(0))
+
+    const res = mockRes()
+    showActivityLog(mockReq(), res)
+
+    const [, { rows }] = res.render.mock.calls[0]
+    expect(rows[0].old_data).toBeNull()
+  })
+
+  test('passes search term through to template', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(0))
+      .mockReturnValueOnce(mockRows([]))
+      .mockReturnValueOnce(mockGetN(0))
+
+    const res = mockRes()
+    showActivityLog(mockReq({ query: { search: 'alice' } }), res)
+
+    const [, { search }] = res.render.mock.calls[0]
+    expect(search).toBe('alice')
+  })
+
+  test('passes category filter through to template', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(0))
+      .mockReturnValueOnce(mockRows([]))
+      .mockReturnValueOnce(mockGetN(0))
+
+    const res = mockRes()
+    showActivityLog(mockReq({ query: { category: 'Auth' } }), res)
+
+    const [, { categoryFilter }] = res.render.mock.calls[0]
+    expect(categoryFilter).toBe('Auth')
+  })
+
+  test('renders error state when DB throws', () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockImplementation(() => { throw new Error('DB down') }) })
+    db.prepare.mockReturnValueOnce(mockGetN(0))
+
+    const res = mockRes()
+    showActivityLog(mockReq(), res)
+
+    const [, { rows, error }] = res.render.mock.calls[0]
+    expect(rows).toHaveLength(0)
+    expect(error).toMatch(/could not load/i)
+  })
+})
+
+// ── showFailedLogins ─────────────────────────────────────────────────────────
+
+describe('showFailedLogins', () => {
+  test('renders failed logins page with correct title and rows', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(2))
+      .mockReturnValueOnce(mockRows([fakeFailedRow, fakeFailedRow]))
+
+    const res = mockRes()
+    showFailedLogins(mockReq(), res)
+
+    expect(res.render).toHaveBeenCalledWith('admin-activity-log', expect.objectContaining({
+      pageTitle: 'Failed Logins',
+      totalRows: 2,
+      showCategoryFilter: false,
+      formAction: '/admin/failed-logins',
+      failedLoginCount: 2,
+    }))
+  })
+
+  test('renders empty state when no failed logins exist', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(0))
+      .mockReturnValueOnce(mockRows([]))
+
+    const res = mockRes()
+    showFailedLogins(mockReq(), res)
+
+    const [, { rows, totalRows }] = res.render.mock.calls[0]
+    expect(rows).toHaveLength(0)
+    expect(totalRows).toBe(0)
+  })
+
+  test('passes search term through to template', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(0))
+      .mockReturnValueOnce(mockRows([]))
+
+    const res = mockRes()
+    showFailedLogins(mockReq({ query: { search: 'bob' } }), res)
+
+    const [, { search }] = res.render.mock.calls[0]
+    expect(search).toBe('bob')
+  })
+
+  test('rows have old_data and new_data set to null', () => {
+    db.prepare
+      .mockReturnValueOnce(mockCount(1))
+      .mockReturnValueOnce(mockRows([fakeFailedRow]))
+
+    const res = mockRes()
+    showFailedLogins(mockReq(), res)
+
+    const [, { rows }] = res.render.mock.calls[0]
+    expect(rows[0].old_data).toBeNull()
+    expect(rows[0].new_data).toBeNull()
+  })
+
+  test('renders error state when DB throws', () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockImplementation(() => { throw new Error('DB down') }) })
+    db.prepare.mockReturnValueOnce(mockGetN(0))
+
+    const res = mockRes()
+    showFailedLogins(mockReq(), res)
+
+    const [, { rows, error }] = res.render.mock.calls[0]
+    expect(rows).toHaveLength(0)
+    expect(error).toMatch(/could not load/i)
+  })
+})

--- a/tests/unit/input-validation.test.js
+++ b/tests/unit/input-validation.test.js
@@ -1,0 +1,100 @@
+/* eslint-env jest */
+const { cleanText, validateRequiredText, validateOptionalText, validateName } = require('../../src/services/input-validation')
+
+describe('cleanText', () => {
+  test('trims leading and trailing whitespace', () => {
+    expect(cleanText('  hello  ')).toBe('hello')
+  })
+
+  test('returns empty string for null', () => {
+    expect(cleanText(null)).toBe('')
+  })
+
+  test('returns empty string for undefined', () => {
+    expect(cleanText(undefined)).toBe('')
+  })
+
+  test('converts non-string values to string', () => {
+    expect(cleanText(123)).toBe('123')
+  })
+})
+
+describe('validateRequiredText', () => {
+  test('returns null for a valid value within limit', () => {
+    expect(validateRequiredText('Title', 'My consultation', 100)).toBeNull()
+  })
+
+  test('returns error when value is empty', () => {
+    expect(validateRequiredText('Title', '', 100)).toBe('Title is required.')
+  })
+
+  test('returns error when value is only whitespace', () => {
+    expect(validateRequiredText('Title', '   ', 100)).toBe('Title is required.')
+  })
+
+  test('returns error when value exceeds maxLength', () => {
+    const long = 'a'.repeat(101)
+    expect(validateRequiredText('Title', long, 100)).toBe('Title must be 100 characters or fewer.')
+  })
+
+  test('returns null when value is exactly at maxLength', () => {
+    const exact = 'a'.repeat(100)
+    expect(validateRequiredText('Title', exact, 100)).toBeNull()
+  })
+
+  test('returns null for null input when treated as empty', () => {
+    expect(validateRequiredText('Title', null, 100)).toBe('Title is required.')
+  })
+})
+
+describe('validateOptionalText', () => {
+  test('returns null for empty value', () => {
+    expect(validateOptionalText('Description', '', 500)).toBeNull()
+  })
+
+  test('returns null for null value', () => {
+    expect(validateOptionalText('Description', null, 500)).toBeNull()
+  })
+
+  test('returns null for value within limit', () => {
+    expect(validateOptionalText('Description', 'Some text', 500)).toBeNull()
+  })
+
+  test('returns error when value exceeds maxLength', () => {
+    const long = 'x'.repeat(501)
+    expect(validateOptionalText('Description', long, 500)).toBe('Description must be 500 characters or fewer.')
+  })
+
+  test('returns null when value is exactly at maxLength', () => {
+    const exact = 'x'.repeat(500)
+    expect(validateOptionalText('Description', exact, 500)).toBeNull()
+  })
+})
+
+describe('validateName', () => {
+  test('returns null for a valid name', () => {
+    expect(validateName('Full name', 'Jane Doe')).toBeNull()
+  })
+
+  test('returns error when name is empty', () => {
+    expect(validateName('Full name', '')).toBe('Full name is required.')
+  })
+
+  test('returns error when name is only whitespace', () => {
+    expect(validateName('Full name', '   ')).toBe('Full name is required.')
+  })
+
+  test('returns error when name exceeds 100 characters', () => {
+    const long = 'a'.repeat(101)
+    expect(validateName('Full name', long)).toBe('Full name must be 100 characters or fewer.')
+  })
+
+  test('returns null when name is exactly 100 characters', () => {
+    const exact = 'a'.repeat(100)
+    expect(validateName('Full name', exact)).toBeNull()
+  })
+
+  test('returns error for null input', () => {
+    expect(validateName('Full name', null)).toBe('Full name is required.')
+  })
+})

--- a/tests/unit/signup-controller.test.js
+++ b/tests/unit/signup-controller.test.js
@@ -35,6 +35,44 @@ beforeEach(() => {
   jest.clearAllMocks() 
 })
 
+describe('name validation', () => {
+  test('rejects a name exceeding 100 characters', async () => {
+    const req = mockReq({
+      fullName: 'a'.repeat(101),
+      number: '1234567',
+      email: 'student@students.wits.ac.za',
+      password: 'Password01',
+      confirmPassword: 'Password01'
+    })
+    req.session = {}
+    const res = mockRes()
+
+    await registerUser(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('sign-up', expect.objectContaining({
+      error: expect.stringContaining('100 characters or fewer')
+    }))
+  })
+
+  test('rejects an empty name', async () => {
+    const req = mockReq({
+      fullName: '',
+      number: '1234567',
+      email: 'student@students.wits.ac.za',
+      password: 'Password01',
+      confirmPassword: 'Password01'
+    })
+    req.session = {}
+    const res = mockRes()
+
+    await registerUser(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('sign-up', expect.objectContaining({
+      error: expect.stringContaining('required')
+    }))
+  })
+})
+
 describe('email domain validation', () => {
   test('accepts student email ending in @students.wits.ac.za', async () => {
     db.prepare


### PR DESCRIPTION
Related #6  
Closes #105

## What Was Changed

### Server-Side Input Validation

Added a reusable `input-validation.js` helper service with the following functions:

- `cleanText`
- `validateRequiredText`
- `validateOptionalText`
- `validateName`

Consultation booking now rejects:

- Titles exceeding 100 characters
- Descriptions exceeding 500 characters

Signup now rejects:

- Empty names
- Names exceeding 100 characters

Availability creation and update now reject:

- Venue values exceeding 100 characters

All validated text input is trimmed before being written to the database.

---

### Output Encoding and SQL Safety Audit

Confirmed that user-supplied output is rendered using escaped EJS output with `<%= %>`.

Unescaped EJS output using `<%- %>` is only used for server-constructed JSON payloads, such as schema metadata and course lists, not raw user input.

Confirmed that database queries continue to use `better-sqlite3` prepared statements with bound parameters. No user-controlled SQL values are inserted using string interpolation.

---

### Failed Logins View

Added a Failed Logins view under the Admin Security section.

The Failed Logins page:

- Opens at `/admin/failed-logins`
- Filters the existing activity log for `AUTH_FAILED_LOGIN` events
- Reuses the existing `activity_log` and `actions` tables
- Does not introduce a separate `failed_login_log` table
- Shows a clean empty state when no failed-login records exist

The Activity Log and Failed Logins pages now share the same Security sidebar structure.

---

### ADR Update

Added Decision 6 to `ADR-012-Security.md`.

This documents:

- The server-side input validation approach
- XSS mitigation through escaped output
- SQL injection prevention through prepared statements and bound parameters

---

## Testing

Added unit tests for all four `input-validation.js` helper functions, reaching 100% coverage for the helper.

Added integration tests for:

- Consultation title length rejection
- Script-tag input being stored as plain text and rendered escaped

Extended signup unit tests for:

- Empty name rejection
- Name length rejection