### PR TITLE
Bug fixes peer review and forgot password 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,27 @@ This script will
 - Seed the initial degrees and courses
 
 This is gitignored — each dev maintains their own local copy.
+
+## Email setup (local development)
+
+Emails (verification codes, login PINs, password resets) are sent via Gmail SMTP. To enable them locally, create a `.env` file in the project root:
+
+```
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your.email@gmail.com
+SMTP_PASS=your-app-password
+EMAIL_FROM="KnockKnock.prof" <your.email@gmail.com>
+APP_URL=http://localhost:3000
+```
+
+**Getting a Gmail App Password:**
+
+Google does not allow regular passwords for SMTP. You need a 16-character App Password:
+
+1. Make sure your Google account has 2-Step Verification enabled
+2. Go to **Google Account → Security → App Passwords**
+3. Click **Create**, give it any name (e.g. "KnockKnock local")
+4. Copy the 16-character password shown and paste it as `SMTP_PASS` — no spaces
+
+Without a `.env` file the app still runs, but any action that triggers an email will log an error and silently continue.

--- a/documentation/ADR's/ADR-010-booking-flow.md
+++ b/documentation/ADR's/ADR-010-booking-flow.md
@@ -91,3 +91,12 @@ Course cards on the student dashboard now have a hover state making them
 visually interactive. Calendar week labels changed from hardcoded
 "This week" / "Next week" to actual date ranges (e.g. "11 May – 15 May") so
 they are unambiguous regardless of the day of the week.
+
+**Calendar density fix (peer review 2026-05-16).**
+Peer review identified the "Find a Consultation" calendar as overwhelming — showing all slots across two full weeks simultaneously produced 50+ visible cards with no way to narrow them down. Two changes were made:
+
+1. *Course chips become active filters.* The coloured course badges above the calendar are now clickable buttons. Selecting a chip (e.g. ELEN3009) hides all slots for other courses and highlights only that course's availability. An "All" chip restores the unfiltered view. This is a pure client-side filter with no additional server requests.
+
+2. *Week 2 collapses by default.* The second week of the calendar is hidden on page load, replaced with a "Show next week" toggle button. The most relevant time window (the next 5 business days) is immediately visible without scrolling or cognitive overload. The toggle respects whatever course filter is active when expanded.
+
+These changes require no schema or controller modifications — only the EJS view and the inline JavaScript block were updated.

--- a/documentation/peer-review-response.md
+++ b/documentation/peer-review-response.md
@@ -40,7 +40,7 @@ A consultation booking is a confirmed arrangement between a student and a lectur
 
 **Clarification:** A cancel button already exists on the consultation detail page. The reviewer may not have encountered it during testing. It prompts for confirmation before cancelling.
 
-**Enhancement planned:** We will add a time-based restriction so that cancellations are blocked within 2 hours of the scheduled start, with a clear message explaining why. A reschedule flow is out of scope for this sprint but noted for backlog.
+**Enhancement implemented:** Cancellations are now blocked within 2 hours of the scheduled start time, with a clear error message explaining why. A reschedule flow is out of scope for this sprint but noted for backlog.
 
 ---
 
@@ -48,7 +48,7 @@ A consultation booking is a confirmed arrangement between a student and a lectur
 
 **Reviewer concern:** Showing all time slots for the full week across all courses is too much information at once.
 
-**Resolution:** Redesigned. The course filter chips at the top of the page now act as active filters — clicking a course badge shows only that course's slots. The view also defaults to showing today's slots only, with a "Show full week" toggle for users who want the broader view. This reduces the default visible content by approximately 80% and makes the purpose of the page (find one slot, book it) much clearer.
+**Resolution:** Redesigned. The course filter chips at the top of the page now act as active filters — clicking a course badge shows only that course's slots, hiding all others. The second week of the calendar is collapsed by default behind a "Show next week" toggle, so users see only the next 5 business days on load. Together these changes reduce the default visible content significantly and make the purpose of the page (find one slot, book it) much clearer.
 
 ---
 
@@ -75,7 +75,7 @@ A consultation booking is a confirmed arrangement between a student and a lectur
 | 1 | Zero courses required | Not enforced — justified above. Validation message added for zero-course save. |
 | 2 | False success on no-op edit | Fixed — zero-course validation blocks the save. |
 | 3 | Bookings persist after course drop | Intentional — bookings are confirmed arrangements. UI note planned. |
-| 4 | No cancel/reschedule button | Cancel exists. Time-based restriction to be added. |
+| 4 | No cancel/reschedule button | Cancel exists. 2-hour restriction implemented. Reschedule in backlog. |
 | 5 | Overwhelming consultation view | Redesigned with course filters and today-first default. |
 | 6 | Logo goes to landing page | Intentional — universal web convention. |
 | 7 | No logout confirmation | Fixed — confirmation dialog added. |

--- a/documentation/peer-review-response.md
+++ b/documentation/peer-review-response.md
@@ -1,0 +1,81 @@
+# Peer Review Response
+
+**Date:** 2026-05-16
+**Branch:** bugFixesPeerReview
+**Reviewer feedback received on:** KnockKnock.prof student-facing flows
+
+---
+
+## 1. A student can have zero courses saved
+
+**Reviewer concern:** The system should require at least one course.
+
+**Our position:** Not enforced — by design.
+
+A student may legitimately have zero courses at certain points in the academic lifecycle: they may have just registered, be between semester enrolments, or have dropped a course while a replacement is being processed. Enforcing a minimum of one course would block these valid states and add friction for no meaningful safety benefit — a student with no courses simply sees no consultation slots to book, which is the correct and safe outcome. We have added a validation message when a student tries to save a course edit with zero courses selected, so the UX is not misleading, but we do not prevent the empty state from existing in the database.
+
+---
+
+## 2. Saving the course edit page with no changes shows "Edits saved successfully"
+
+**Reviewer concern:** No-op saves give a false success message.
+
+**Resolution:** Fixed. We now validate that at least one course is selected before saving. If the student submits the form with zero courses ticked, the page renders an inline error ("Please select at least one course before saving.") and does not write to the database. This addresses both the false success message and the zero-course edge case from item 1.
+
+---
+
+## 3. Removing a course does not cancel existing bookings for that lecturer
+
+**Reviewer concern:** Booked consultations remain visible after the associated course is dropped.
+
+**Our position:** Intentional — bookings are independent once confirmed.
+
+A consultation booking is a confirmed arrangement between a student and a lecturer. Automatically cancelling it when a course is removed would be disruptive and surprising — the student may have an important meeting scheduled. The correct flow is for the student to explicitly cancel the booking themselves if they no longer need it. The cancel button is available on the consultation detail page. We acknowledge this could be clearer in the UI and will add a note on the student dashboard if their active bookings include courses they are no longer enrolled in.
+
+---
+
+## 4. There is no cancel or reschedule button for booked meetings
+
+**Reviewer concern:** Students cannot cancel a meeting close to the scheduled time.
+
+**Clarification:** A cancel button already exists on the consultation detail page. The reviewer may not have encountered it during testing. It prompts for confirmation before cancelling.
+
+**Enhancement planned:** We will add a time-based restriction so that cancellations are blocked within 2 hours of the scheduled start, with a clear message explaining why. A reschedule flow is out of scope for this sprint but noted for backlog.
+
+---
+
+## 5. The "Find a Consultation" page is overwhelming
+
+**Reviewer concern:** Showing all time slots for the full week across all courses is too much information at once.
+
+**Resolution:** Redesigned. The course filter chips at the top of the page now act as active filters — clicking a course badge shows only that course's slots. The view also defaults to showing today's slots only, with a "Show full week" toggle for users who want the broader view. This reduces the default visible content by approximately 80% and makes the purpose of the page (find one slot, book it) much clearer.
+
+---
+
+## 6. Pressing the logo navigates to the landing page
+
+**Reviewer concern:** Unsure if this is intentional.
+
+**Our position:** Intentional. The logo acting as a home link is a universal web convention (established by Nielsen Norman Group research). Authenticated users landing on the home page are immediately redirected to their dashboard, so there is no functional disruption. No change made.
+
+---
+
+## 7. The logout button has no confirmation
+
+**Reviewer concern:** Accidental logouts are possible.
+
+**Resolution:** Implemented. A browser confirmation dialog ("Are you sure you want to log out?") now appears before the logout request is sent. This is a single line of JavaScript on the logout link and adds no friction to intentional logouts.
+
+---
+
+## Summary
+
+| # | Concern | Action |
+|---|---------|--------|
+| 1 | Zero courses required | Not enforced — justified above. Validation message added for zero-course save. |
+| 2 | False success on no-op edit | Fixed — zero-course validation blocks the save. |
+| 3 | Bookings persist after course drop | Intentional — bookings are confirmed arrangements. UI note planned. |
+| 4 | No cancel/reschedule button | Cancel exists. Time-based restriction to be added. |
+| 5 | Overwhelming consultation view | Redesigned with course filters and today-first default. |
+| 6 | Logo goes to landing page | Intentional — universal web convention. |
+| 7 | No logout confirmation | Fixed — confirmation dialog added. |

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,0 +1,7 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('form[action="/logout"]').forEach(form => {
+    form.addEventListener('submit', e => {
+      if (!confirm('Are you sure you want to log out?')) e.preventDefault()
+    })
+  })
+})

--- a/src/controllers/auth-controller.js
+++ b/src/controllers/auth-controller.js
@@ -73,6 +73,8 @@ const login = async (req, res) => {
         req.session.userRole = 'lecturer'
         req.session.showWelcome = true
         await logActivity(staff.staff_number, ActionTypes.USER_LOGIN, [])
+        const hasLecturerCourses = db.prepare('SELECT 1 FROM staff_courses WHERE staff_number = ? LIMIT 1').get(staff.staff_number)
+        if (!hasLecturerCourses) return res.redirect('/lecturer/courses/edit?onboarding=true')
         return res.redirect('/lecturer/dashboard?welcome=1')
       }
 
@@ -114,6 +116,8 @@ const login = async (req, res) => {
         req.session.userRole = 'student'
         req.session.showWelcome = true
         await logActivity(student.student_number, ActionTypes.USER_LOGIN, [])
+        const hasEnrollments = db.prepare('SELECT 1 FROM enrollments WHERE student_number = ? LIMIT 1').get(student.student_number)
+        if (!hasEnrollments) return res.redirect('/student/courses?onboarding=true')
         return res.redirect('/student/dashboard?welcome=1')
       } 
       

--- a/src/controllers/consultation-detail-controller.js
+++ b/src/controllers/consultation-detail-controller.js
@@ -114,6 +114,12 @@ const cancelConsultation = async (req, res) => {
     return res.redirect(`/consultations/${constId}?error=Consultation+is+already+cancelled`)
   }
 
+  const consultationStart = new Date(`${consultation.consultation_date}T${consultation.consultation_time}:00`)
+  const twoHoursFromNow = new Date(Date.now() + 2 * 60 * 60 * 1000)
+  if (consultationStart <= twoHoursFromNow) {
+    return res.redirect(`/consultations/${constId}?error=Consultations+cannot+be+cancelled+within+2+hours+of+the+start+time`)
+  }
+
   db.prepare(`UPDATE consultations SET status = 'Cancelled' WHERE const_id = ?`).run(constId);
   db.prepare('DELETE FROM consultation_attendees WHERE const_id = ?').run(constId);
   await logActivity(req.session.userId, ActionTypes.CONSULT_CANCEL_ORG, [{ table: 'consultations', id: req.params.constId }]);

--- a/src/controllers/password-reset-controller.js
+++ b/src/controllers/password-reset-controller.js
@@ -8,6 +8,14 @@ const TOKEN_EXPIRY_MS = 60 * 60 * 1000 // 1 hour
 
 const hashToken = (raw) => crypto.createHash('sha256').update(raw).digest('hex')
 
+const lookupByEmail = (email) => {
+  const student = db.prepare('SELECT * FROM students WHERE email = ?').get(email)
+  if (student) return { user: student, table: 'students', idCol: 'student_number' }
+  const staff = db.prepare('SELECT * FROM staff WHERE email = ?').get(email)
+  if (staff) return { user: staff, table: 'staff', idCol: 'staff_number' }
+  return null
+}
+
 const lookupByIdentifier = (identifier) => {
   const student = db.prepare('SELECT * FROM students WHERE CAST(student_number AS TEXT) = ?').get(identifier)
   if (student) return { user: student, table: 'students', idCol: 'student_number' }

--- a/src/controllers/student-courses-controller.js
+++ b/src/controllers/student-courses-controller.js
@@ -83,6 +83,10 @@ const updateStudentCourses = async (req, res) => {
     ? (Array.isArray(courses) ? courses : [courses])
     : []
 
+  if (courseList.length === 0) {
+    return res.redirect('/student/courses?error=Please+select+at+least+one+course+before+saving.')
+  }
+
   for (const code of courseList) {
     const course = db.prepare(
       'SELECT course_code FROM courses WHERE course_code = ?'

--- a/src/views/admin-activity-log.html
+++ b/src/views/admin-activity-log.html
@@ -407,5 +407,6 @@
   });
 </script>
 
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/views/admin-dashboard.html
+++ b/src/views/admin-dashboard.html
@@ -709,5 +709,6 @@ function formatCol(name) {
       });
     });
   </script>
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/views/availability.html
+++ b/src/views/availability.html
@@ -243,5 +243,6 @@
   });
 </script>
 
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/views/homepage.html
+++ b/src/views/homepage.html
@@ -836,5 +836,6 @@
   <script
     src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
   ></script>
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/views/lecturer-consultations.html
+++ b/src/views/lecturer-consultations.html
@@ -216,5 +216,6 @@
   </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/views/lecturer-courses-edit.html
+++ b/src/views/lecturer-courses-edit.html
@@ -219,5 +219,6 @@
     else document.querySelectorAll('.course-item').forEach(item => { item.style.display = ''; });
   });
 </script>
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/views/lecturer-courses.html
+++ b/src/views/lecturer-courses.html
@@ -96,5 +96,6 @@
   </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/views/lecturer-dashboard.html
+++ b/src/views/lecturer-dashboard.html
@@ -313,5 +313,6 @@
 <script>
   document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
 </script>
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/views/lecturer-settings.html
+++ b/src/views/lecturer-settings.html
@@ -89,5 +89,6 @@
   </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/src/views/student-dashboard.html
+++ b/src/views/student-dashboard.html
@@ -307,11 +307,17 @@
               <p class="text-muted mb-2" style="font-size:0.75rem;">🚪 No public holidays in the next 10 days — all doors are fully operational.</p>
             <% } %>
 
-            <!-- Course colour legend -->
+            <!-- Course filter chips -->
             <% if (Object.keys(colourMap).length > 0) { %>
-            <div class="d-flex flex-wrap gap-2 mb-3">
+            <div class="d-flex flex-wrap gap-2 mb-3 align-items-center">
+              <button class="badge rounded-pill border-0 course-chip active-chip" id="chip-ALL"
+                      style="background-color:#064735;font-size:0.75rem;cursor:pointer;"
+                      onclick="filterByCourse('ALL')">All</button>
               <% Object.entries(colourMap).forEach(([code, colour]) => { %>
-                <span class="badge rounded-pill" style="background-color:<%= colour %>; font-size:0.75rem;"><%= code %></span>
+                <button class="badge rounded-pill border-0 course-chip" id="chip-<%= code %>"
+                        style="background-color:<%= colour %>88;font-size:0.75rem;cursor:pointer;color:#111;"
+                        data-active-colour="<%= colour %>"
+                        onclick="filterByCourse('<%= code %>')"><%= code %></button>
               <% }) %>
             </div>
             <% } %>
@@ -363,7 +369,8 @@
                       %>
                       <div class="avail-slot <%= isPast ? 'past-slot' : '' %>"
                            style="background-color:<%= slot.course_colour %>18; border-left-color:<%= slot.course_colour %>;"
-                           data-staff="<%= slot.staff_number %>">
+                           data-staff="<%= slot.staff_number %>"
+                           data-course="<%= slot.course_code %>">
                         <div style="color:<%= slot.course_colour %>; font-weight:600;"><%= slot.course_code %></div>
                         <div><%= slot.start_time %>–<%= slot.end_time %></div>
                         <div class="text-muted"><%= slot.lecturer_name %></div>
@@ -393,6 +400,10 @@
             </div>
 
             <!-- Week 2 -->
+            <button class="btn btn-sm btn-outline-secondary mb-2" id="week2-toggle" onclick="toggleWeek2()" style="font-size:0.8rem;">
+              Show next week <i class="bi bi-chevron-down ms-1"></i>
+            </button>
+            <div id="week2-section" style="display:none;">
             <div class="fw-semibold text-muted small mb-2"><%= week2Label %></div>
             <div class="d-flex gap-2 calendar-row overflow-auto pb-2">
               <% calendarDays.slice(5, 10).forEach(dateStr => { %>
@@ -427,7 +438,8 @@
                       %>
                       <div class="avail-slot <%= isPast2 ? 'past-slot' : '' %>"
                            style="background-color:<%= slot.course_colour %>18; border-left-color:<%= slot.course_colour %>;"
-                           data-staff="<%= slot.staff_number %>">
+                           data-staff="<%= slot.staff_number %>"
+                           data-course="<%= slot.course_code %>">
                         <div style="color:<%= slot.course_colour %>; font-weight:600;"><%= slot.course_code %></div>
                         <div><%= slot.start_time %>–<%= slot.end_time %></div>
                         <div class="text-muted"><%= slot.lecturer_name %></div>
@@ -452,6 +464,7 @@
                 </div>
               <% }) %>
             </div>
+            </div><!-- /week2-section -->
 
           <% } %>
         </div>
@@ -595,29 +608,54 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
+  let activeCourse = 'ALL';
+
+  function filterByCourse(code) {
+    activeCourse = code;
+    document.querySelectorAll('.course-chip').forEach(chip => {
+      const isActive = chip.id === 'chip-' + code;
+      const colour = chip.dataset.activeColour;
+      if (isActive) {
+        chip.classList.add('active-chip');
+        chip.style.backgroundColor = chip.id === 'chip-ALL' ? '#064735' : colour;
+        chip.style.color = '#fff';
+      } else {
+        chip.classList.remove('active-chip');
+        chip.style.backgroundColor = chip.id === 'chip-ALL' ? '#06473540' : (chip.dataset.activeColour + '55');
+        chip.style.color = '#111';
+      }
+    });
+    document.querySelectorAll('.avail-slot[data-course]').forEach(el => {
+      el.style.display = (code === 'ALL' || el.dataset.course === code) ? '' : 'none';
+    });
+  }
+
+  function toggleWeek2() {
+    const sec = document.getElementById('week2-section');
+    const btn = document.getElementById('week2-toggle');
+    const hidden = sec.style.display === 'none';
+    sec.style.display = hidden ? '' : 'none';
+    btn.innerHTML = hidden
+      ? 'Hide next week <i class="bi bi-chevron-up ms-1"></i>'
+      : 'Show next week <i class="bi bi-chevron-down ms-1"></i>';
+    if (hidden) filterByCourse(activeCourse);
+  }
+
   function setFilter(mode) {
     const btnAvail = document.getElementById('filter-availability');
-    const btnLec = document.getElementById('filter-lecturer');
-    const sel = document.getElementById('lecturer-select');
+    const btnLec   = document.getElementById('filter-lecturer');
+    const sel      = document.getElementById('lecturer-select');
     if (mode === 'availability') {
-      btnAvail.classList.add('btn-primary', 'active');
-      btnAvail.classList.remove('btn-outline-secondary');
-      btnLec.classList.remove('btn-primary', 'active');
-      btnLec.classList.add('btn-outline-secondary');
+      btnAvail.classList.add('btn-primary','active'); btnAvail.classList.remove('btn-outline-secondary');
+      btnLec.classList.remove('btn-primary','active'); btnLec.classList.add('btn-outline-secondary');
       sel.style.display = 'none';
-      showAllSlots();
+      filterByCourse(activeCourse);
     } else {
-      btnLec.classList.add('btn-primary', 'active');
-      btnLec.classList.remove('btn-outline-secondary');
-      btnAvail.classList.remove('btn-primary', 'active');
-      btnAvail.classList.add('btn-outline-secondary');
+      btnLec.classList.add('btn-primary','active'); btnLec.classList.remove('btn-outline-secondary');
+      btnAvail.classList.remove('btn-primary','active'); btnAvail.classList.add('btn-outline-secondary');
       sel.style.display = '';
       filterByLecturer(sel.value);
     }
-  }
-
-  function showAllSlots() {
-    document.querySelectorAll('.avail-slot').forEach(el => el.style.display = '');
   }
 
   function filterByLecturer(staffNumber) {

--- a/src/views/student-dashboard.html
+++ b/src/views/student-dashboard.html
@@ -666,5 +666,6 @@
 
   document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
 </script>
+<script src="/js/app.js"></script>
 </body>
 </html>

--- a/tests/integration/greeting.test.js
+++ b/tests/integration/greeting.test.js
@@ -14,17 +14,23 @@ beforeAll(() => {
       ('A999001', 'Test Lecturer', 'testlecturer@wits.ac.za', 'EIE', 'EIE', ?, 1)
   `).run(BCRYPT_HASH);
 
+  db.prepare(`INSERT OR IGNORE INTO staff_courses (staff_number, course_code) VALUES ('A999001', 'ELEN4010')`).run();
+
   db.prepare(`
     INSERT OR IGNORE INTO students
       (student_number, name, email, password, degree_code, email_verified)
     VALUES
       (9999001, 'Test Student', 'teststudent@students.wits.ac.za', ?, 'BSCENGINFO', 1)
   `).run(BCRYPT_HASH);
+
+  db.prepare(`INSERT OR IGNORE INTO enrollments (student_number, course_code) VALUES (9999001, 'ELEN4010')`).run();
 });
 
 afterAll(() => {
-  db.prepare(`DELETE FROM staff    WHERE staff_number   = 'A999001'`).run();
-  db.prepare(`DELETE FROM students WHERE student_number = 9999001`).run();
+  db.prepare(`DELETE FROM staff_courses WHERE staff_number   = 'A999001'`).run();
+  db.prepare(`DELETE FROM enrollments   WHERE student_number = 9999001`).run();
+  db.prepare(`DELETE FROM staff         WHERE staff_number   = 'A999001'`).run();
+  db.prepare(`DELETE FROM students      WHERE student_number = 9999001`).run();
 });
 
 describe('Login greeting message (Issue #64)', () => {

--- a/tests/unit/auth-controller.test.js
+++ b/tests/unit/auth-controller.test.js
@@ -109,8 +109,9 @@ describe('showLogin', () => {
 describe('login', () => {
   test('sets lecturer session and redirects to lecturer dashboard on valid staff credentials', async () => {
     db.prepare
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) }) // SELECT staff
-      .mockReturnValueOnce({ run: jest.fn() })                            // UPDATE failed_attempts = 0
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) })              // SELECT staff
+      .mockReturnValueOnce({ run: jest.fn() })                                         // UPDATE failed_attempts = 0
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ staff_number: 'A000356' }) }) // SELECT staff_courses
 
     const req = mockReq({ body: { staffStudentNumber: 'A000356', password: VALID_PASSWORD } })
     const res = mockRes()
@@ -123,11 +124,26 @@ describe('login', () => {
     expect(res.redirect).toHaveBeenCalledWith('/lecturer/dashboard?welcome=1')
   })
 
+  test('redirects new lecturer with no courses to course setup', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStaff) }) // SELECT staff
+      .mockReturnValueOnce({ run: jest.fn() })                            // UPDATE failed_attempts = 0
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })      // SELECT staff_courses (none)
+
+    const req = mockReq({ body: { staffStudentNumber: 'A000356', password: VALID_PASSWORD } })
+    const res = mockRes()
+
+    await login(req, res)
+
+    expect(res.redirect).toHaveBeenCalledWith('/lecturer/courses/edit?onboarding=true')
+  })
+
   test('sets student session and redirects to student dashboard on valid student credentials', async () => {
     db.prepare
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })        // SELECT staff (not found)
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStudent) }) // SELECT student
-      .mockReturnValueOnce({ run: jest.fn() })                              // UPDATE failed_attempts = 0
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })                        // SELECT staff (not found)
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStudent) })                 // SELECT student
+      .mockReturnValueOnce({ run: jest.fn() })                                              // UPDATE failed_attempts = 0
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ student_number: 1234567 }) }) // SELECT enrollments
 
     const req = mockReq({ body: { staffStudentNumber: '1234567', password: VALID_PASSWORD } })
     const res = mockRes()
@@ -138,6 +154,21 @@ describe('login', () => {
     expect(req.session.userName).toBe('Aditya')
     expect(req.session.userRole).toBe('student')
     expect(res.redirect).toHaveBeenCalledWith('/student/dashboard?welcome=1')
+  })
+
+  test('redirects new student with no courses to course setup', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })        // SELECT staff (not found)
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStudent) }) // SELECT student
+      .mockReturnValueOnce({ run: jest.fn() })                              // UPDATE failed_attempts = 0
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })        // SELECT enrollments (none)
+
+    const req = mockReq({ body: { staffStudentNumber: '1234567', password: VALID_PASSWORD } })
+    const res = mockRes()
+
+    await login(req, res)
+
+    expect(res.redirect).toHaveBeenCalledWith('/student/courses?onboarding=true')
   })
 
   test('sets admin session and redirects to admin dashboard on valid admin credentials', async () => {

--- a/tests/unit/consultation-detail-controller.test.js
+++ b/tests/unit/consultation-detail-controller.test.js
@@ -48,9 +48,21 @@ describe('cancelConsultation', () => {
     expect(res.redirect).toHaveBeenCalledWith('/consultations/42?error=Consultation+is+already+cancelled')
   })
 
+  test('blocks cancellation within 2 hours of start time', async () => {
+    const soonDate = new Date(Date.now() + 30 * 60 * 1000)
+    const soonDateStr = soonDate.toISOString().slice(0, 10)
+    const soonTime = soonDate.toISOString().slice(11, 16)
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue({ organiser: 1234567, status: 'Open', consultation_date: soonDateStr, consultation_time: soonTime }) })
+    const res = mockRes()
+    await cancelConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/consultations/42?error=Consultations+cannot+be+cancelled+within+2+hours+of+the+start+time')
+  })
+
   test('cancels and redirects to dashboard on success', async () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000)
+    const futureDateStr = futureDate.toISOString().slice(0, 10)
     db.prepare
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ organiser: 1234567, status: 'Open' }) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ organiser: 1234567, status: 'Open', consultation_date: futureDateStr, consultation_time: '10:00' }) })
       .mockReturnValueOnce({ run: jest.fn() })
       .mockReturnValueOnce({ run: jest.fn() })
     const res = mockRes()

--- a/tests/unit/consultation-detail-controller.test.js
+++ b/tests/unit/consultation-detail-controller.test.js
@@ -1,0 +1,109 @@
+/* eslint-env jest */
+jest.mock('../../database/db', () => ({ prepare: jest.fn() }))
+jest.mock('../../src/services/logging-service', () => ({ logActivity: jest.fn().mockResolvedValue(true) }))
+jest.mock('../../src/services/consultation-join-service', () => ({ validateJoin: jest.fn() }))
+
+const db = require('../../database/db')
+const { validateJoin } = require('../../src/services/consultation-join-service')
+const { cancelConsultation, leaveConsultation, joinConsultation } = require('../../src/controllers/consultation-detail-controller')
+
+const mockReq = (overrides = {}) => ({
+  session: { userId: 1234567, userName: 'Test Student', userRole: 'student' },
+  params: { constId: '42' },
+  query: {},
+  ...overrides
+})
+const mockRes = () => {
+  const r = {}
+  r.render = jest.fn()
+  r.redirect = jest.fn()
+  r.status = jest.fn().mockReturnValue(r)
+  return r
+}
+
+beforeEach(() => {
+  db.prepare.mockReset()
+  validateJoin.mockReset()
+})
+
+describe('cancelConsultation', () => {
+  test('redirects to dashboard when consultation not found', async () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+    const res = mockRes()
+    await cancelConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/student/dashboard?error=Consultation+not+found')
+  })
+
+  test('redirects with error when user is not the organiser', async () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue({ organiser: 9999999, status: 'Open' }) })
+    const res = mockRes()
+    await cancelConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/consultations/42?error=Only+the+organiser+can+cancel+this+consultation')
+  })
+
+  test('redirects with error when consultation is already cancelled', async () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue({ organiser: 1234567, status: 'Cancelled' }) })
+    const res = mockRes()
+    await cancelConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/consultations/42?error=Consultation+is+already+cancelled')
+  })
+
+  test('cancels and redirects to dashboard on success', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ organiser: 1234567, status: 'Open' }) })
+      .mockReturnValueOnce({ run: jest.fn() })
+      .mockReturnValueOnce({ run: jest.fn() })
+    const res = mockRes()
+    await cancelConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/student/dashboard?success=Consultation+cancelled+successfully')
+  })
+})
+
+describe('leaveConsultation', () => {
+  test('redirects to dashboard when consultation not found', async () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+    const res = mockRes()
+    await leaveConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/student/dashboard?error=Consultation+not+found')
+  })
+
+  test('redirects with error when user is the organiser', async () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue({ organiser: 1234567 }) })
+    const res = mockRes()
+    await leaveConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/consultations/42?error=Organisers+must+cancel+not+leave')
+  })
+
+  test('redirects with error when student is not an attendee', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ organiser: 9999999 }) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+    const res = mockRes()
+    await leaveConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/consultations/42?error=You+are+not+attending+this+consultation')
+  })
+
+  test('removes attendee and redirects to dashboard on success', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ organiser: 9999999 }) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ student_number: 1234567 }) })
+      .mockReturnValueOnce({ run: jest.fn() })
+    const res = mockRes()
+    await leaveConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/student/dashboard?success=You+have+left+the+consultation')
+  })
+})
+
+describe('joinConsultation', () => {
+  test('redirects with error when student is not enrolled in the lecturer course', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ const_id: '42', lecturer_id: 'A000356' }) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([]) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+    validateJoin.mockReturnValue({ valid: true })
+
+    const res = mockRes()
+    await joinConsultation(mockReq(), res)
+    expect(res.redirect).toHaveBeenCalledWith('/student/dashboard?error=You+are+not+enrolled+in+a+course+taught+by+this+lecturer')
+  })
+})

--- a/tests/unit/lecturer-courses-controller.test.js
+++ b/tests/unit/lecturer-courses-controller.test.js
@@ -57,6 +57,44 @@ describe('showLecturerCourses', () => {
   })
 })
 
+describe('showLecturerCoursesEdit', () => {
+  test('renders edit view with courses and departments', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ dept_code: 'EIE' }) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([{ department_code: 'EIE', department_name: 'EIE', dept_code: 'EIE' }]) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([{ course_code: 'ELEN4010', course_name: 'Lab', year_level: 4, dept_code: 'EIE' }]) })
+      .mockReturnValueOnce({ all: jest.fn().mockReturnValue([{ course_code: 'ELEN4010' }]) })
+
+    const req = mockReq()
+    const res = mockRes()
+    await showLecturerCoursesEdit(req, res)
+    expect(res.render).toHaveBeenCalledWith('lecturer-courses-edit', expect.objectContaining({
+      lecturerDeptCode: 'EIE',
+      error: null
+    }))
+  })
+
+  test('renders error view when staff record not found', async () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+    const req = mockReq()
+    const res = mockRes()
+    await showLecturerCoursesEdit(req, res)
+    expect(res.render).toHaveBeenCalledWith('lecturer-courses-edit', expect.objectContaining({
+      error: 'Staff record not found.'
+    }))
+  })
+
+  test('renders error view when DB throws', async () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockImplementation(() => { throw new Error('DB error') }) })
+    const req = mockReq()
+    const res = mockRes()
+    await showLecturerCoursesEdit(req, res)
+    expect(res.render).toHaveBeenCalledWith('lecturer-courses-edit', expect.objectContaining({
+      error: 'Could not load course data. Please try again.'
+    }))
+  })
+})
+
 describe('updateLecturerCourses', () => {
   test('redirects to dashboard on valid submission', async () => {
     const req = mockReq({ body: { department_code: 'EIE', courses: ['ELEN4010', 'ELEN3009'] } })
@@ -77,5 +115,34 @@ describe('updateLecturerCourses', () => {
     const res = mockRes()
     await updateLecturerCourses(req, res)
     expect(res.redirect).toHaveBeenCalledWith('/lecturer/dashboard?success=true')
+  })
+
+  test('redirects with error when staff record not found', async () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+    const req = mockReq({ body: { department_code: 'EIE', courses: ['ELEN4010'] } })
+    const res = mockRes()
+    await updateLecturerCourses(req, res)
+    expect(res.redirect).toHaveBeenCalledWith('/lecturer/courses/edit?error=Staff+record+not+found.')
+  })
+
+  test('redirects with error when department is invalid', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ staff_number: 'A000356' }) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+    const req = mockReq({ body: { department_code: 'FAKE', courses: [] } })
+    const res = mockRes()
+    await updateLecturerCourses(req, res)
+    expect(res.redirect).toHaveBeenCalledWith('/lecturer/courses/edit?error=Invalid+department+selected.')
+  })
+
+  test('redirects with error when a course code is invalid', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ staff_number: 'A000356' }) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ dept_code: 'EIE' }) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+    const req = mockReq({ body: { department_code: 'EIE', courses: ['FAKE9999'] } })
+    const res = mockRes()
+    await updateLecturerCourses(req, res)
+    expect(res.redirect).toHaveBeenCalledWith('/lecturer/courses/edit?error=Invalid+course+selected.')
   })
 })

--- a/tests/unit/lecturer-settings-controller.test.js
+++ b/tests/unit/lecturer-settings-controller.test.js
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+jest.mock('../../database/db', () => ({ prepare: jest.fn() }))
+
+const db = require('../../database/db')
+const { showLecturerSettings } = require('../../src/controllers/lecturer-settings-controller')
+
+const mockReq = (overrides = {}) => ({
+  session: { userId: 'A000356', userName: 'Bruce Wayne', userRole: 'lecturer' },
+  ...overrides
+})
+const mockRes = () => { const r = {}; r.render = jest.fn(); return r }
+
+beforeEach(() => db.prepare.mockReset())
+
+describe('showLecturerSettings', () => {
+  test('renders with profile when DB returns a record', () => {
+    const profile = { staff_number: 'A000356', name: 'Bruce Wayne', email: 'b@wits.ac.za', department: 'EIE', dept_code: 'EIE' }
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(profile) })
+
+    const res = mockRes()
+    showLecturerSettings(mockReq(), res)
+
+    expect(res.render).toHaveBeenCalledWith('lecturer-settings', expect.objectContaining({
+      profile,
+      error: null
+    }))
+  })
+
+  test('renders with empty profile when DB returns nothing', () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+
+    const res = mockRes()
+    showLecturerSettings(mockReq(), res)
+
+    expect(res.render).toHaveBeenCalledWith('lecturer-settings', expect.objectContaining({
+      profile: {},
+      error: null
+    }))
+  })
+
+  test('renders with error message when DB throws', () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockImplementation(() => { throw new Error('DB down') }) })
+
+    const res = mockRes()
+    showLecturerSettings(mockReq(), res)
+
+    expect(res.render).toHaveBeenCalledWith('lecturer-settings', expect.objectContaining({
+      error: 'Could not load profile. Please try again.'
+    }))
+  })
+})

--- a/tests/unit/password-reset-controller.test.js
+++ b/tests/unit/password-reset-controller.test.js
@@ -48,12 +48,12 @@ describe('showForgotPassword', () => {
 })
 
 describe('requestPasswordReset', () => {
-  test('sends email and shows sent=true when email matches a student', async () => {
+  test('sends email and shows sent=true when student number matches', async () => {
     db.prepare
-      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStudent) }) // SELECT students
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(fakeStudent) }) // SELECT students by identifier
       .mockReturnValueOnce({ run: jest.fn() })                              // UPDATE reset_token
 
-    const req = mockReq({ body: { email: fakeStudent.email } })
+    const req = mockReq({ body: { identifier: String(fakeStudent.student_number) } })
     const res = mockRes()
     await requestPasswordReset(req, res)
 
@@ -61,12 +61,12 @@ describe('requestPasswordReset', () => {
     expect(res.render).toHaveBeenCalledWith('forgot-password', { sent: true, error: null })
   })
 
-  test('still shows sent=true when email is not found (no enumeration)', async () => {
+  test('still shows sent=true when identifier is not found (no enumeration)', async () => {
     db.prepare
       .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) }) // students
       .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) }) // staff
 
-    const req = mockReq({ body: { email: 'nobody@wits.ac.za' } })
+    const req = mockReq({ body: { identifier: '9999999' } })
     const res = mockRes()
     await requestPasswordReset(req, res)
 

--- a/tests/unit/student-courses-controller.test.js
+++ b/tests/unit/student-courses-controller.test.js
@@ -159,8 +159,7 @@ describe('updateStudentCourses', () => {
     expect(res.redirect).toHaveBeenCalledWith('/student/courses?error=Invalid+degree+selected.')
   })
 
-  test('handles zero courses selected (no courses key in body)', async () => {
-    // Arrange
+  test('rejects save with zero courses and redirects with error', async () => {
     db.prepare.mockReturnValue({
       get: jest.fn().mockReturnValue({ degree_code: 'BSCENGINFO' }),
       run: jest.fn()
@@ -171,11 +170,9 @@ describe('updateStudentCourses', () => {
     })
     const res = mockRes()
 
-    // Act
     await updateStudentCourses(req, res)
 
-    // Assert
-    expect(res.redirect).toHaveBeenCalledWith('/student/dashboard?success=true')
+    expect(res.redirect).toHaveBeenCalledWith('/student/courses?error=Please+select+at+least+one+course+before+saving.')
   })
 
   test('handles a single course submitted as a string', async () => {

--- a/tests/unit/verify-controller.test.js
+++ b/tests/unit/verify-controller.test.js
@@ -6,7 +6,7 @@ jest.mock('../../src/services/email-service', () => ({
   sendVerificationEmail: jest.fn().mockResolvedValue(undefined)
 }))
 
-const { verifyEmail, resendCode } = require('../../src/controllers/verify-controller')
+const { showVerifyPage, verifyEmail, resendCode } = require('../../src/controllers/verify-controller')
 const db = require('../../database/db')
 const { sendVerificationEmail } = require('../../src/services/email-service')
 
@@ -27,6 +27,29 @@ const pastExpiry = () => new Date(Date.now() - 1000).toISOString()
 beforeEach(() => {
   db.prepare.mockReset()
   sendVerificationEmail.mockClear()
+})
+
+describe('showVerifyPage', () => {
+  test('renders with emailFailed message when query flag is set', () => {
+    const req = { query: { email: 'a@wits.ac.za', emailFailed: '1' } }
+    const res = mockRes()
+    showVerifyPage(req, res)
+    expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
+      email: 'a@wits.ac.za',
+      message: expect.stringContaining('trouble sending'),
+      error: null
+    }))
+  })
+
+  test('renders with fromLogin message when query flag is set', () => {
+    const req = { query: { email: 'b@wits.ac.za', fromLogin: '1' } }
+    const res = mockRes()
+    showVerifyPage(req, res)
+    expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
+      message: expect.stringContaining('not yet verified'),
+      error: null
+    }))
+  })
 })
 
 describe('POST /verify-email', () => {
@@ -153,6 +176,40 @@ describe('POST /verify-email/resend', () => {
     expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
       message: 'A new code has been sent to your email.',
       error: null,
+    }))
+  })
+
+  test('renders error when no account found for email', async () => {
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue(null) })
+    const req = mockReq({ email: 'ghost@wits.ac.za' })
+    const res = mockRes()
+    await resendCode(req, res)
+    expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
+      error: 'No account found for this email address.'
+    }))
+  })
+
+  test('redirects to login when account is already verified', async () => {
+    db.prepare.mockReturnValueOnce({ get: jest.fn().mockReturnValue({ email_verified: 1, resend_count: 0 }) })
+    const req = mockReq({ email: 'test@students.wits.ac.za' })
+    const res = mockRes()
+    await resendCode(req, res)
+    expect(res.redirect).toHaveBeenCalledWith('/login?success=Email+already+verified.+Please+log+in.')
+  })
+
+  test('renders error when email send fails', async () => {
+    const { sendVerificationEmail } = require('../../src/services/email-service')
+    sendVerificationEmail.mockRejectedValueOnce(new Error('SMTP down'))
+    db.prepare
+      .mockReturnValueOnce({ get: jest.fn().mockReturnValue({ student_number: 1, email_verified: 0, resend_count: 0 }) })
+      .mockReturnValueOnce({ run: jest.fn() })
+    const req = mockReq({ email: 'test@students.wits.ac.za' })
+    const res = mockRes()
+    await resendCode(req, res)
+    expect(res.render).toHaveBeenCalledWith('verify-email', expect.objectContaining({
+      error: expect.stringContaining('could not send')
     }))
   })
 


### PR DESCRIPTION
## Summary

Branch: `bugFixesPeerReview`

### Bug Fixes

- **Forgot password flow:** Changed the forgot-password form to accept a student/staff number instead of an email address. The system now looks up the account by identifier and sends the reset link to the email stored in the database — fixing the UX mismatch where students log in with their number but were asked for an email they may not remember.

- **Email on Render:** Fixed outbound SMTP failing with `ENETUNREACH` on Render's free tier (which blocks IPv6). Added `dns.setDefaultResultOrder('ipv4first')` at the top of `app.js` to force IPv4 DNS resolution globally.

- **Zero-course validation:** Submitting the student course-edit form with no courses selected now shows an inline error and does not write to the database, preventing a false "Edits saved successfully" message.

- **2-hour cancellation restriction:** Students can no longer cancel a consultation within 2 hours of its scheduled start time. A clear error message is shown explaining why.

- **Logout confirmation:** A browser confirmation dialog now appears before the logout request is sent, preventing accidental logouts.

### Features

- **Onboarding redirect:** New students and lecturers who have no courses after signing up are redirected to their respective course setup page on first login, rather than landing on an empty dashboard.

### UI Improvements

- **Consultation calendar density:** Course chips on the student dashboard now act as active filters — clicking a chip hides all other courses' slots. The second week of the calendar is collapsed by default behind a "Show next week" toggle, significantly reducing the amount of information shown on load.

### Documentation

- **Peer review response:** Added `documentation/peer-review-response.md` addressing all 7 points raised by the peer reviewer, with justifications for intentional design decisions and descriptions of all changes made.

- **Local email setup guide:** Added an "Email setup (local development)" section to the README explaining how to create a `.env` file with Gmail SMTP credentials and how to generate a Gmail App Password.

- **ADR-010 updated:** Documented the calendar density fix (chips-as-filters, week-2-collapse) in the booking flow ADR.

### Tests

- Improved overall test coverage from ~89% to **93%** (438 tests passing).
- Added unit tests for: `lecturer-settings-controller`, `consultation-detail-controller` (including 2-hour restriction), `verify-controller` edge cases, `lecturer-courses-controller` error paths.
- Updated existing tests to reflect the forgot-password redesign, zero-course redirect, and onboarding redirect.
- Updated integration greeting tests to seed course data so new test users don't hit the onboarding redirect.
- All 16 E2E tests pass.

Closes #122 