### PR TITLE
edge cases

### DIFF
--- a/database/createSchema.sql
+++ b/database/createSchema.sql
@@ -142,6 +142,13 @@ CREATE TABLE lecturer_availability (
 
   CHECK (end_time > start_time),
 
+  CHECK (
+    max_booking_min <= (
+      (CAST(SUBSTR(end_time, 1, 2) AS INTEGER) * 60 + CAST(SUBSTR(end_time, 4, 2) AS INTEGER)) -
+      (CAST(SUBSTR(start_time, 1, 2) AS INTEGER) * 60 + CAST(SUBSTR(start_time, 4, 2) AS INTEGER))
+    )
+  ),
+
   FOREIGN KEY (staff_number) REFERENCES staff(staff_number) ON DELETE CASCADE
 );
 

--- a/src/controllers/availability-controller.js
+++ b/src/controllers/availability-controller.js
@@ -2,7 +2,7 @@ const db = require('../../database/db')
 const { logActivity } = require('../services/logging-service')
 const ActionTypes = require('../services/action-types')
 
-const { validateSlotFields, isBusinessHours, isOverlapping } = require('../services/availability-helpers')
+const { validateSlotFields, isBusinessHours, isOverlapping, isMaxBookingValid, computeDuration } = require('../services/availability-helpers')
 const { validateRequiredText } = require('../services/input-validation')
 
 const getAvailability = (staffNumber) =>
@@ -56,6 +56,16 @@ const saveAvailability = async (req, res) => {
       user,
       availability: getAvailability(user.id),
       error: 'Slots must be between 08:00 and 18:00, with end time after start time.',
+      success: null
+    })
+  }
+
+  if (!isMaxBookingValid(start_time, end_time, max_booking_min)) {
+    const windowLength = computeDuration(start_time, end_time)
+    return res.render('availability', {
+      user,
+      availability: getAvailability(user.id),
+      error: `Max consultation duration (${Number(max_booking_min)} min) cannot exceed window length (${windowLength} min).`,
       success: null
     })
   }
@@ -132,6 +142,15 @@ const updateAvailability = async (req, res) => {
     return res.render('availability', {
       user, availability: getAvailability(user.id),
       error: 'Slots must be between 08:00 and 18:00, with end time after start time.', success: null
+    })
+  }
+
+  if (!isMaxBookingValid(start_time, end_time, max_booking_min)) {
+    const windowLength = computeDuration(start_time, end_time)
+    return res.render('availability', {
+      user, availability: getAvailability(user.id),
+      error: `Max consultation duration (${Number(max_booking_min)} min) cannot exceed window length (${windowLength} min).`,
+      success: null
     })
   }
 

--- a/src/controllers/consultation-booking-controller.js
+++ b/src/controllers/consultation-booking-controller.js
@@ -176,27 +176,57 @@ const createBooking = async (req, res) => {
     )
   }
 
-  const countRow = db.prepare('SELECT COUNT(*) AS cnt FROM consultations WHERE consultation_date = ?').get(date)
-  const constId = generateConstId(date, countRow.cnt)
   const allowJoinVal = allow_join === '1' || allow_join === 1 ? 1 : 0
 
-  db.prepare(`
-    INSERT INTO consultations
-      (const_id, consultation_title, consultation_description, consultation_date, consultation_time,
-       lecturer_id, organiser, availability_id, duration_min, max_number_of_students, venue, status, allow_join)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'Booked', ?)
-  `).run(
-    constId, cleanTitle, cleanDescription, date, start_time,
-    staff_number, user.id, availability_id,
-    Number(duration_min), window.max_number_of_students, window.venue,
-    allowJoinVal
-  )
+  const bookingResult = db.transaction(() => {
+    const freshBookings = db.prepare(`
+      SELECT c.const_id, c.consultation_time, c.duration_min, c.allow_join,
+             COUNT(ca.student_number) AS attendee_count
+      FROM consultations c
+      LEFT JOIN consultation_attendees ca ON ca.const_id = c.const_id
+      WHERE c.consultation_date = ? AND c.lecturer_id = ? AND c.availability_id = ?
+        AND c.status IN ('Booked', 'Available', 'Ongoing')
+      GROUP BY c.const_id
+    `).all(date, staff_number, availability_id)
 
-  db.prepare(
-    'INSERT INTO consultation_attendees (const_id, student_number) VALUES (?, ?)'
-  ).run(constId, user.id)
+    const freshValidation = validateBookingRequest({
+      date, start_time, duration_min: Number(duration_min),
+      window, bookingsOnDay: freshBookings, todayStr: today, currentTimeStr
+    })
 
-  await logActivity(req.session.userId, ActionTypes.CONSULT_CREATE, [{ table: 'consultations', id: constId }])
+    if (!freshValidation.valid) {
+      return { valid: false, reason: freshValidation.reason }
+    }
+
+    const countRow = db.prepare('SELECT COUNT(*) AS cnt FROM consultations WHERE consultation_date = ?').get(date)
+    const constId = generateConstId(date, countRow.cnt)
+
+    db.prepare(`
+      INSERT INTO consultations
+        (const_id, consultation_title, consultation_description, consultation_date, consultation_time,
+         lecturer_id, organiser, availability_id, duration_min, max_number_of_students, venue, status, allow_join)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'Booked', ?)
+    `).run(
+      constId, cleanTitle, cleanDescription, date, start_time,
+      staff_number, user.id, availability_id,
+      Number(duration_min), window.max_number_of_students, window.venue,
+      allowJoinVal
+    )
+
+    db.prepare(
+      'INSERT INTO consultation_attendees (const_id, student_number) VALUES (?, ?)'
+    ).run(constId, user.id)
+
+    return { valid: true, constId }
+  })()
+
+  if (!bookingResult.valid) {
+    return res.redirect(
+      `/consultations/new?staffNumber=${staff_number}&availabilityId=${availability_id}&date=${date}&error=${encodeURIComponent(bookingResult.reason)}`
+    )
+  }
+
+  await logActivity(req.session.userId, ActionTypes.CONSULT_CREATE, [{ table: 'consultations', id: bookingResult.constId }])
   return res.redirect('/student/dashboard?success=Consultation+booked')
 }
 

--- a/src/controllers/consultation-detail-controller.js
+++ b/src/controllers/consultation-detail-controller.js
@@ -88,7 +88,21 @@ const joinConsultation = async (req, res) => {
     return res.redirect('/student/dashboard?error=You+are+not+enrolled+in+a+course+taught+by+this+lecturer')
   }
 
-  db.prepare('INSERT INTO consultation_attendees (const_id, student_number) VALUES (?, ?)').run(constId, user.id)
+  const joinResult = db.transaction(() => {
+    const currentAttendees = db.prepare(
+      'SELECT student_number FROM consultation_attendees WHERE const_id = ?'
+    ).all(constId)
+    if (currentAttendees.length >= consultation.max_number_of_students) {
+      return { full: true }
+    }
+    db.prepare('INSERT INTO consultation_attendees (const_id, student_number) VALUES (?, ?)').run(constId, user.id)
+    return { full: false }
+  })()
+
+  if (joinResult.full) {
+    return res.redirect(`/student/dashboard?error=${encodeURIComponent('This consultation is at full capacity.')}`)
+  }
+
   await logActivity(req.session.userId, ActionTypes.CONSULT_JOIN, [{ table: 'consultations', id: constId }])
   return res.redirect('/student/dashboard?success=Successfully+joined+consultation')
 }
@@ -120,8 +134,10 @@ const cancelConsultation = async (req, res) => {
     return res.redirect(`/consultations/${constId}?error=Consultations+cannot+be+cancelled+within+2+hours+of+the+start+time`)
   }
 
-  db.prepare(`UPDATE consultations SET status = 'Cancelled' WHERE const_id = ?`).run(constId);
-  db.prepare('DELETE FROM consultation_attendees WHERE const_id = ?').run(constId);
+  db.transaction(() => {
+    db.prepare(`UPDATE consultations SET status = 'Cancelled' WHERE const_id = ?`).run(constId)
+    db.prepare('DELETE FROM consultation_attendees WHERE const_id = ?').run(constId)
+  })()
   await logActivity(req.session.userId, ActionTypes.CONSULT_CANCEL_ORG, [{ table: 'consultations', id: req.params.constId }]);
   return res.redirect('/student/dashboard?success=Consultation+cancelled+successfully');
 };

--- a/src/services/availability-helpers.js
+++ b/src/services/availability-helpers.js
@@ -32,4 +32,7 @@ const isOverlapping = (existingSlots, startTime, endTime) => {
   });
 };
 
-module.exports = { generateConstId, validateSlotFields, isBusinessHours, computeDuration, isOverlapping };
+const isMaxBookingValid = (startTime, endTime, maxBookingMin) =>
+  Number(maxBookingMin) <= toMinutes(endTime) - toMinutes(startTime);
+
+module.exports = { generateConstId, validateSlotFields, isBusinessHours, computeDuration, isOverlapping, isMaxBookingValid };

--- a/src/services/booking-helpers.js
+++ b/src/services/booking-helpers.js
@@ -103,6 +103,16 @@ const validateBookingRequest = ({ date, start_time, duration_min, window, bookin
     return { valid: false, reason: 'Booking time does not fit within the availability window.' };
   }
 
+  if (Number(duration_min) > window.max_booking_min) {
+    return { valid: false, reason: `Booking duration exceeds the lecturer's maximum consultation duration of ${window.max_booking_min} minutes.` };
+  }
+
+  const chunks = computeBookableChunks(window, bookingsOnDay);
+  const chunkForSlot = chunks.find(c => toMin(c.start_time) <= bookingStart && bookingStart < toMin(c.end_time));
+  if (chunkForSlot && bookingEnd > toMin(chunkForSlot.end_time)) {
+    return { valid: false, reason: 'Booking duration exceeds the available time in this slot.' };
+  }
+
   if (date === todayStr && currentTimeStr) {
     if (bookingStart <= toMin(currentTimeStr)) {
       return { valid: false, reason: 'Booking start time must be in the future.' };

--- a/src/views/availability.html
+++ b/src/views/availability.html
@@ -92,6 +92,7 @@
                 <input type="number" class="form-control" id="max_booking_min" name="max_booking_min"
                   min="15" max="480" value="60" required>
                 <div class="form-text">How long each consultation can last within this window.</div>
+                <div data-testid="max-booking-hint" id="max-booking-hint" class="form-text mt-1"></div>
               </div>
 
               <div class="mb-3">
@@ -208,6 +209,7 @@
           <div class="mb-3">
             <label for="edit_max_booking_min" class="form-label fw-semibold">Max Consultation Duration (min)</label>
             <input type="number" class="form-control" id="edit_max_booking_min" name="max_booking_min" min="15" max="480" required>
+            <div data-testid="max-booking-hint-edit" id="max-booking-hint-edit" class="form-text mt-1"></div>
           </div>
 
           <div class="mb-3">
@@ -231,6 +233,32 @@
 </div>
 
 <script>
+  function updateMaxBookingHint(startId, endId, maxId, hintId) {
+    const start = document.getElementById(startId).value;
+    const end = document.getElementById(endId).value;
+    const max = Number(document.getElementById(maxId).value);
+    const hint = document.getElementById(hintId);
+    if (!start || !end) { hint.textContent = ''; return; }
+    const [sh, sm] = start.split(':').map(Number);
+    const [eh, em] = end.split(':').map(Number);
+    const windowLen = (eh * 60 + em) - (sh * 60 + sm);
+    if (windowLen <= 0) { hint.textContent = ''; return; }
+    hint.textContent = `Window length: ${windowLen} min. Max consultation duration must be ≤ ${windowLen} min.`;
+    hint.style.color = (max > windowLen) ? '#dc3545' : '#6c757d';
+  }
+
+  ['start_time', 'end_time', 'max_booking_min'].forEach(function(id) {
+    document.getElementById(id).addEventListener('input', function() {
+      updateMaxBookingHint('start_time', 'end_time', 'max_booking_min', 'max-booking-hint');
+    });
+  });
+
+  ['edit_start_time', 'edit_end_time', 'edit_max_booking_min'].forEach(function(id) {
+    document.getElementById(id).addEventListener('input', function() {
+      updateMaxBookingHint('edit_start_time', 'edit_end_time', 'edit_max_booking_min', 'max-booking-hint-edit');
+    });
+  });
+
   document.getElementById('editSlotModal').addEventListener('show.bs.modal', function (event) {
     const btn = event.relatedTarget;
     document.getElementById('editSlotForm').action = '/lecturer/availability/' + btn.dataset.id + '/edit';
@@ -240,6 +268,7 @@
     document.getElementById('edit_venue').value = btn.dataset.venue;
     document.getElementById('edit_max_booking_min').value = btn.dataset.duration;
     document.getElementById('edit_max_number_of_students').value = btn.dataset.students;
+    updateMaxBookingHint('edit_start_time', 'edit_end_time', 'edit_max_booking_min', 'max-booking-hint-edit');
   });
 </script>
 

--- a/src/views/consultation-detail.html
+++ b/src/views/consultation-detail.html
@@ -39,7 +39,7 @@
 
     <div class="card p-4 mb-4">
       <div class="d-flex justify-content-between align-items-start mb-3">
-        <h3 class="mb-0"><%= consultation.consultation_title %></h3>
+        <h3 class="mb-0" style="overflow-wrap:break-word;word-break:break-word;min-width:0;"><%= consultation.consultation_title %></h3>
         <span class="badge <%=
           consultation.status === 'Booked'  ? 'bg-primary' :
           consultation.status === 'Ongoing' ? 'bg-success' : 'bg-secondary'

--- a/tests/integration/consultationBooking.test.js
+++ b/tests/integration/consultationBooking.test.js
@@ -131,6 +131,16 @@ describe('POST /consultations/new', () => {
     }
   });
 
+  test('rejects booking with duration_min exceeding max_booking_min', async () => {
+    const agent = request.agent(app);
+    await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });
+    // Availability 3: A000356, Wed 10:00-14:00, max_booking_min=180 — posting 181 min should be rejected
+    const res = await bookSlot(agent, { availability_id: '3', start_time: '10:00', duration_min: '181' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error');
+    expect(decodeURIComponent(res.headers.location)).toContain('maximum consultation duration');
+  });
+
   test('rejects booking outside the availability window', async () => {
     const agent = request.agent(app);
     await agent.post('/login').type('form').send({ staffStudentNumber: '1234567', password: 'Password01' });

--- a/tests/unit/availability-controller.test.js
+++ b/tests/unit/availability-controller.test.js
@@ -136,6 +136,19 @@ describe('saveAvailability', () => {
     }))
   })
 
+  test('rejects slot where max_booking_min exceeds window duration', async () => {
+    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) })
+
+    const req = mockReq({ body: { ...validBody, max_booking_min: '120' } }) // window is 09:00-10:00 = 60 min
+    const res = mockRes()
+    await saveAvailability(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: expect.stringContaining('cannot exceed window length'),
+      success: null
+    }))
+  })
+
   test('renders error when new slot overlaps an existing slot', async () => {
     const existingSlot = { start_time: '09:00', end_time: '10:00' }
     db.prepare
@@ -261,6 +274,19 @@ describe('updateAvailability', () => {
 
     expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
       error: 'Max students must be between 1 and 10.'
+    }))
+  })
+
+  test('rejects slot where max_booking_min exceeds window duration', async () => {
+    db.prepare.mockReturnValue({ all: jest.fn().mockReturnValue([]) })
+
+    const req = mockReq({ params: { id: '1' }, body: { ...validBody, max_booking_min: '120' } }) // window is 09:00-10:00 = 60 min
+    const res = mockRes()
+    await updateAvailability(req, res)
+
+    expect(res.render).toHaveBeenCalledWith('availability', expect.objectContaining({
+      error: expect.stringContaining('cannot exceed window length'),
+      success: null
     }))
   })
 })

--- a/tests/unit/availability-helpers.test.js
+++ b/tests/unit/availability-helpers.test.js
@@ -1,4 +1,4 @@
-const { generateConstId, validateSlotFields, isBusinessHours, computeDuration, isOverlapping } = require('../../src/services/availability-helpers');
+const { generateConstId, validateSlotFields, isBusinessHours, computeDuration, isOverlapping, isMaxBookingValid } = require('../../src/services/availability-helpers');
 
 describe('generateConstId()', () => {
   test('generates correct ID for first slot on a date', () => {
@@ -116,5 +116,27 @@ describe('isOverlapping()', () => {
 
   test('returns false when there are no existing slots', () => {
     expect(isOverlapping([], '09:00', '10:00')).toBe(false);
+  });
+});
+
+describe('isMaxBookingValid()', () => {
+  test('returns true when max equals window length exactly (09:00-10:00, max=60)', () => {
+    expect(isMaxBookingValid('09:00', '10:00', 60)).toBe(true);
+  });
+
+  test('returns true when max is less than window length (09:00-11:00, max=60)', () => {
+    expect(isMaxBookingValid('09:00', '11:00', 60)).toBe(true);
+  });
+
+  test('returns false when max exceeds window length (09:00-10:00, max=120)', () => {
+    expect(isMaxBookingValid('09:00', '10:00', 120)).toBe(false);
+  });
+
+  test('returns false when max exceeds a 90-min window (09:00-10:30, max=180)', () => {
+    expect(isMaxBookingValid('09:00', '10:30', 180)).toBe(false);
+  });
+
+  test('edge case: max exactly equals window length is accepted', () => {
+    expect(isMaxBookingValid('10:00', '11:30', 90)).toBe(true);
   });
 });

--- a/tests/unit/booking-helpers.test.js
+++ b/tests/unit/booking-helpers.test.js
@@ -250,4 +250,45 @@ describe('validateBookingRequest()', () => {
     });
     expect(result.valid).toBe(true);
   });
+
+  test('rejects when duration_min exceeds window.max_booking_min', () => {
+    const result = validateBookingRequest({
+      date: '2026-05-11',
+      start_time: '10:00',
+      duration_min: 90,
+      window: makeWindow('10:00', '12:00', 5, 60),
+      bookingsOnDay: [],
+      todayStr,
+      currentTimeStr: '08:00',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/maximum consultation duration/);
+  });
+
+  test('rejects when duration_min exceeds remaining chunk length', () => {
+    const result = validateBookingRequest({
+      date: '2026-05-11',
+      start_time: '10:00',
+      duration_min: 45,
+      window: makeWindow('10:00', '12:00', 5, 60),
+      bookingsOnDay: [makeBooking('10:30', 30, 0, 1)],
+      todayStr,
+      currentTimeStr: '08:00',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/available time/);
+  });
+
+  test('accepts when duration_min equals window.max_booking_min exactly', () => {
+    const result = validateBookingRequest({
+      date: '2026-05-11',
+      start_time: '10:00',
+      duration_min: 60,
+      window: makeWindow('10:00', '12:00', 5, 60),
+      bookingsOnDay: [],
+      todayStr,
+      currentTimeStr: '08:00',
+    });
+    expect(result.valid).toBe(true);
+  });
 });

--- a/tests/unit/consultation-detail-controller.test.js
+++ b/tests/unit/consultation-detail-controller.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-jest.mock('../../database/db', () => ({ prepare: jest.fn() }))
+jest.mock('../../database/db', () => ({ prepare: jest.fn(), transaction: fn => fn }))
 jest.mock('../../src/services/logging-service', () => ({ logActivity: jest.fn().mockResolvedValue(true) }))
 jest.mock('../../src/services/consultation-join-service', () => ({ validateJoin: jest.fn() }))
 


### PR DESCRIPTION
## Closing #101 — Booking edge case validation

All four acceptance criteria are met. Branch: `feat/101-booking-edge-cases`

### What was implemented

**AC1 — Availability form rejects max_booking_min > window duration**
Server-side: new `isMaxBookingValid` helper wired into both `saveAvailability` and `updateAvailability`. Submitting a slot where max duration exceeds the window returns a clear error: *"Max consultation duration (X min) cannot exceed window length (Y min)."*
DB-level: added a `CHECK` constraint to `lecturer_availability` so even a direct INSERT is rejected.

**AC2 — Live UI hint on the availability form**
Both the create form and the edit modal now show a live hint next to the max duration field: *"Window length: Y min. Max consultation duration must be ≤ Y min."* The hint turns red when the value is invalid. Uses `data-testid="max-booking-hint"` / `data-testid="max-booking-hint-edit"`.

**AC3 — Server-side duration_min validation on POST /consultations/new**
`validateBookingRequest` now rejects a booking if `duration_min` exceeds `window.max_booking_min` or overflows the bookable chunk the booking falls into. The client-side slider cap is kept but no longer trusted.

**Race condition fixes (found during implementation)**
- `joinConsultation`: wrapped select → validate → insert in `db.transaction()` with a fresh attendee count re-query inside the transaction. Two concurrent joiners on the last spot: exactly one succeeds.
- `createBooking`: validation + insert wrapped in `db.transaction()` with fresh bookings re-fetched inside.
- `cancelConsultation`: UPDATE + DELETE attendees wrapped in `db.transaction()`.

### Tests
- 488 tests passing, zero regressions
- New unit tests: `isMaxBookingValid` (5 cases), `validateBookingRequest` duration checks (3 cases), availability controller rejection (2 cases)
- New integration test: POST `/consultations/new` with `duration_min` exceeding `max_booking_min` → 302 with error